### PR TITLE
Change Mac OS X to OS X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Templates for building your Atom package and running its specs:
 
 ### Why is the language set to objective-c for Travis CI?
 
-Atom has only been released for Mac OS X and Windows and setting the `language`
-to `objective-c` tells Travis CI to run the build on a Mac OS X worker. You can
+Atom has only been released for OS X and Windows and setting the `language`
+to `objective-c` tells Travis CI to run the build on a OS X worker. You can
 read more about it [here](http://blog.travis-ci.com/introducing-mac-ios-rubymotion-testing).
 
 ### What version of Atom is used to run the specs?


### PR DESCRIPTION
Apple has renamed Mac OS X to OS X.