### PR TITLE
Optionally Install Packages Required For Specs To Succeed

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -16,6 +16,16 @@ echo "Downloading package dependencies..."
 atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm clean
 atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install
 
+TEST_PACKAGES="${APM_TEST_PACKAGES:=none}"
+
+if [ "$TEST_PACKAGES" != "none" ]; then
+  echo "Installing atom package dependencies..."
+  for pack in $TEST_PACKAGES ; do
+    echo "Installing $pack..."
+    atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install $pack
+  done
+fi
+
 if [ -f ./node_modules/.bin/coffeelint ]; then
   if [ -d ./lib ]; then
     echo "Linting package..."

--- a/build-package.sh
+++ b/build-package.sh
@@ -21,7 +21,6 @@ TEST_PACKAGES="${APM_TEST_PACKAGES:=none}"
 if [ "$TEST_PACKAGES" != "none" ]; then
   echo "Installing atom package dependencies..."
   for pack in $TEST_PACKAGES ; do
-    echo "Installing $pack..."
     atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install $pack
   done
 fi


### PR DESCRIPTION
Suppose a package has an autocomplete-plus provider. It has specs that test the valid functioning of the provider. Consequently, they need autocomplete-plus installed prior to running `apm test`.

This PR adds optional logic that will install required package(s) during the build. If `APM_TEST_PACKAGES` is unset, nothing will be installed. If you define the following in your `.travis.yml`, the packages (separated by `space`) will be installed:

For a single package:
```yaml
env:
  - APM_TEST_PACKAGES="autocomplete-plus"
```

Or, for multiple packages:
```yaml
env:
  - APM_TEST_PACKAGES="autocomplete-plus some-other-package-here"
```