### PR TITLE
Simplify appveyor.yml And Add build-package.ps1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,19 @@
 version: "{build}"
-os: Windows Server 2012 R2
+
+platform: x64
+
+environment:
+  APM_TEST_PACKAGES:
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+install:
+  - ps: Install-Product node 5
+
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
 
 test: off
 deploy: off
-
-install:
-  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
-  - AtomSetup.exe /silent
-
-build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
-  - apm clean
-  - apm install
-  - apm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@ version: "{build}"
 
 platform: x64
 
+branches:
+    only:
+      - master
+
+skip_tags: true
+
 environment:
   APM_TEST_PACKAGES:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,13 @@ os: Windows Server 2012 R2
 test: off
 deploy: off
 
-init:
-  - cmd: rd /s /q %CHOCOLATEYINSTALL%
-  - ps: iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
-
 install:
-  - cinst atom -y
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%/atom/bin/apm install"
+  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
+  - AtomSetup.exe /silent
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"
+  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
+  - apm clean
+  - apm install
+  - apm test

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,4 +1,6 @@
 Set-StrictMode -Version Latest
+$script:PACKAGE_FOLDER = "$env:APPVEYOR_BUILD_FOLDER"
+Set-Location $script:PACKAGE_FOLDER
 $script:ATOM_CHANNEL = "stable"
 $script:ATOM_DIRECTORY_NAME = "Atom"
 if ($env:ATOM_CHANNEL -and ($env:ATOM_CHANNEL.tolower() -ne "stable")) {
@@ -8,15 +10,15 @@ if ($env:ATOM_CHANNEL -and ($env:ATOM_CHANNEL.tolower() -ne "stable")) {
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(1).tolower()
 }
 
-$script:ATOM_EXE_PATH = "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME\atom.exe"
-$script:ATOM_SCRIPT_PATH = "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME\resources\cli\atom.cmd"
-$script:APM_SCRIPT_PATH = "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin\apm.cmd"
+$script:ATOM_EXE_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\atom.exe"
+$script:ATOM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\cli\atom.cmd"
+$script:APM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin\apm.cmd"
 
 
 function DownloadAtom() {
     Write-Host "Downloading latest Atom release..."
     $source = "https://atom.io/download/windows_zip?channel=$script:ATOM_CHANNEL"
-    $destination = "$PSScriptRoot\atom.zip"
+    $destination = "$script:PACKAGE_FOLDER\atom.zip"
     appveyor DownloadFile $source -FileName $destination
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE
@@ -24,8 +26,8 @@ function DownloadAtom() {
 }
 
 function ExtractAtom() {
-    Remove-Item "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME" -Recurse -ErrorAction Ignore
-    Unzip "$PSScriptRoot\atom.zip" "$PSScriptRoot"
+    Remove-Item "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME" -Recurse -ErrorAction Ignore
+    Unzip "$script:PACKAGE_FOLDER\atom.zip" "$script:PACKAGE_FOLDER"
 }
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -77,17 +79,17 @@ function InstallDependencies() {
 }
 
 function RunLinters() {
-    $libpath = "$PSScriptRoot\lib"
+    $libpath = "$script:PACKAGE_FOLDER\lib"
     $libpathexists = Test-Path $libpath
-    $srcpath = "$PSScriptRoot\src"
+    $srcpath = "$script:PACKAGE_FOLDER\src"
     $srcpathexists = Test-Path $srcpath
-    $specpath = "$PSScriptRoot\spec"
+    $specpath = "$script:PACKAGE_FOLDER\spec"
     $specpathexists = Test-Path $specpath
-    $coffeelintpath = "$PSScriptRoot\node_modules\.bin\coffeelint.cmd"
+    $coffeelintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\coffeelint.cmd"
     $coffeelintpathexists = Test-Path $coffeelintpath
-    $eslintpath = "$PSScriptRoot\node_modules\.bin\eslint.cmd"
+    $eslintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\eslint.cmd"
     $eslintpathexists = Test-Path $eslintpath
-    $standardpath = "$PSScriptRoot\node_modules\.bin\standard.cmd"
+    $standardpath = "$script:PACKAGE_FOLDER\node_modules\.bin\standard.cmd"
     $standardpathexists = Test-Path $standardpath
     if (($libpathexists -or $srcpathexists) -and ($coffeelintpathexists -or $eslintpathexists -or $standardpathexists)) {
         Write-Host "Linting package..."
@@ -165,7 +167,7 @@ function RunLinters() {
 }
 
 function RunSpecs() {
-    $specpath = "$PSScriptRoot\spec"
+    $specpath = "$script:PACKAGE_FOLDER\spec"
     $specpathexists = Test-Path $specpath
     if (!$specpathexists) {
         Write-Host "Missing spec folder! Please consider adding a test suite in '.\spec'"
@@ -192,7 +194,7 @@ function ExitWithCode
 
 function SetElectronEnvironmentVariables
 {
-  # TODO: Remove OS=cygwin once stable is >= Electron 0.36.7
+  # TODO: Remove OS=cygwin once master is >= Electron 0.36.7
   $env:OS = "cygwin"
   [Environment]::SetEnvironmentVariable("OS", "cygwin", "User")
   $env:ELECTRON_NO_ATTACH_CONSOLE = "true"

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,0 +1,211 @@
+Set-StrictMode -Version Latest
+$script:ATOM_CHANNEL = "stable"
+$script:ATOM_DIRECTORY_NAME = "Atom"
+if ($env:ATOM_CHANNEL -and ($env:ATOM_CHANNEL.tolower() -ne "stable")) {
+    $script:ATOM_CHANNEL = "$env:ATOM_CHANNEL"
+    $script:ATOM_DIRECTORY_NAME = "$script:ATOM_DIRECTORY_NAME "
+    $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(0,1).toupper()
+    $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(1).tolower()
+}
+
+$script:ATOM_EXE_PATH = "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME\atom.exe"
+$script:ATOM_SCRIPT_PATH = "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME\resources\cli\atom.cmd"
+$script:APM_SCRIPT_PATH = "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin\apm.cmd"
+
+
+function DownloadAtom() {
+    Write-Host "Downloading latest Atom release..."
+    $source = "https://atom.io/download/windows_zip?channel=$script:ATOM_CHANNEL"
+    $destination = "$PSScriptRoot\atom.zip"
+    appveyor DownloadFile $source -FileName $destination
+    if ($LASTEXITCODE -ne 0) {
+        ExitWithCode -exitcode $LASTEXITCODE
+    }
+}
+
+function ExtractAtom() {
+    Remove-Item "$PSScriptRoot\$script:ATOM_DIRECTORY_NAME" -Recurse -ErrorAction Ignore
+    Unzip "$PSScriptRoot\atom.zip" "$PSScriptRoot"
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+function PrintVersions() {
+    Write-Host -NoNewLine "Using Atom version: "
+    & "$script:ATOM_SCRIPT_PATH" -v
+    if ($LASTEXITCODE -ne 0) {
+        ExitWithCode -exitcode $LASTEXITCODE
+    }
+    Write-Host "Using APM version: "
+    & "$script:APM_SCRIPT_PATH" -v
+    if ($LASTEXITCODE -ne 0) {
+        ExitWithCode -exitcode $LASTEXITCODE
+    }
+}
+
+function InstallPackage() {
+    Write-Host "Downloading package dependencies..."
+    & "$script:APM_SCRIPT_PATH" clean
+    if ($LASTEXITCODE -ne 0) {
+        ExitWithCode -exitcode $LASTEXITCODE
+    }
+    & "$script:APM_SCRIPT_PATH" install
+    if ($LASTEXITCODE -ne 0) {
+        ExitWithCode -exitcode $LASTEXITCODE
+    }
+    InstallDependencies
+}
+
+function InstallDependencies() {
+    if ($env:APM_TEST_PACKAGES) {
+        Write-Host "Installing atom package dependencies..."
+        $APM_TEST_PACKAGES = $env:APM_TEST_PACKAGES -split "\s+"
+        $APM_TEST_PACKAGES | foreach {
+            Write-Host "$_"
+            & "$script:APM_SCRIPT_PATH" install $_
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+    }
+}
+
+function RunLinters() {
+    $libpath = "$PSScriptRoot\lib"
+    $libpathexists = Test-Path $libpath
+    $srcpath = "$PSScriptRoot\src"
+    $srcpathexists = Test-Path $srcpath
+    $specpath = "$PSScriptRoot\spec"
+    $specpathexists = Test-Path $specpath
+    $coffeelintpath = "$PSScriptRoot\node_modules\.bin\coffeelint.cmd"
+    $coffeelintpathexists = Test-Path $coffeelintpath
+    $eslintpath = "$PSScriptRoot\node_modules\.bin\eslint.cmd"
+    $eslintpathexists = Test-Path $eslintpath
+    $standardpath = "$PSScriptRoot\node_modules\.bin\standard.cmd"
+    $standardpathexists = Test-Path $standardpath
+    if (($libpathexists -or $srcpathexists) -and ($coffeelintpathexists -or $eslintpathexists -or $standardpathexists)) {
+        Write-Host "Linting package..."
+    }
+
+    if ($libpathexists) {
+        if ($coffeelintpathexists) {
+            & "$coffeelintpath" lib
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($eslintpathexists) {
+            & "$eslintpath" lib
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($standardpathexists) {
+            & "$standardpath" lib/**/*.js
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+    }
+
+    if ($srcpathexists) {
+        if ($coffeelintpathexists) {
+            & "$coffeelintpath" src
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($eslintpathexists) {
+            & "$eslintpath" src
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($standardpathexists) {
+            & "$standardpath" src/**/*.js
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+    }
+
+    if ($specpathexists -and ($coffeelintpathexists -or $eslintpathexists -or $standardpathexists)) {
+        Write-Host "Linting package specs..."
+        if ($coffeelintpathexists) {
+            & "$coffeelintpath" spec
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($eslintpathexists) {
+            & "$eslintpath" spec
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($standardpathexists) {
+            & "$standardpath" spec/**/*.js
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+    }
+}
+
+function RunSpecs() {
+    $specpath = "$PSScriptRoot\spec"
+    $specpathexists = Test-Path $specpath
+    if (!$specpathexists) {
+        Write-Host "Missing spec folder! Please consider adding a test suite in '.\spec'"
+        ExitWithCode -exitcode 1
+    }
+    Write-Host "Running specs..."
+    & "$script:ATOM_SCRIPT_PATH" --test spec
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Specs Failed"
+        ExitWithCode -exitcode $LASTEXITCODE
+    }
+}
+
+function ExitWithCode
+{
+    param
+    (
+        $exitcode
+    )
+
+    $host.SetShouldExit($exitcode)
+    exit
+}
+
+function SetElectronEnvironmentVariables
+{
+  # TODO: Remove OS=cygwin once stable is >= Electron 0.36.7
+  $env:OS = "cygwin"
+  [Environment]::SetEnvironmentVariable("OS", "cygwin", "User")
+  $env:ELECTRON_NO_ATTACH_CONSOLE = "true"
+  [Environment]::SetEnvironmentVariable("ELECTRON_NO_ATTACH_CONSOLE", "true", "User")
+  $env:ELECTRON_ENABLE_LOGGING = "YES"
+  [Environment]::SetEnvironmentVariable("ELECTRON_ENABLE_LOGGING", "YES", "User")
+
+}
+
+DownloadAtom
+ExtractAtom
+SetElectronEnvironmentVariables
+PrintVersions
+InstallPackage
+RunLinters
+RunSpecs

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -40,7 +40,7 @@ function Unzip
 
 function PrintVersions() {
     Write-Host -NoNewLine "Using Atom version: "
-    & "$script:ATOM_SCRIPT_PATH" -v
+    & "$script:ATOM_EXE_PATH" --version
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE
     }
@@ -174,7 +174,7 @@ function RunSpecs() {
         ExitWithCode -exitcode 1
     }
     Write-Host "Running specs..."
-    & "$script:ATOM_SCRIPT_PATH" --test spec
+    & "$script:ATOM_EXE_PATH" --test spec 2>&1 | %{ "$_" }
     if ($LASTEXITCODE -ne 0) {
         Write-Host "Specs Failed"
         ExitWithCode -exitcode $LASTEXITCODE


### PR DESCRIPTION
This PR:

- [x] Uses the Windows .zip instead of the package installer
- [x] Enables a build matrix for `stable` and `beta` (and potentially others, if they ever exist)
- [x] Replicates the approach used for `build-package.sh` in `build-package.ps1`
- [x] Enables linting on Windows with `coffeelint`, `eslint`, and `standard`
- [x] In the `appveyor.yml`, suppresses building on branches other than master or on tags (which a package author is free to remove when they use this file)
- [x] Installs any packages required to run the package author's specs, using the `APM_TEST_PACKAGES` environment variable (which is space delimited), mirroring the approach used for Travis + `build-package.sh`
- [x] Prints the current version information for `atom` and `apm`
- [x] Fix issue with finding `atom.cmd` on beta channel
- [x] Redirect stdout to stderr to suppress red highlighting of stderr (still determining if red highlighting is desirable or distracting)

**Note:** There is an outstanding issue where the atom version isn't being displayed correctly because `atom -v` is exiting prematurely. This is partially addressed in https://github.com/atom/atom/pull/10950 and will need to be further fixed in an additional PR that prevents the process from exiting prior to `atom -v` printing the version.