### PR TITLE
Run package specs in 1.0 API preview mode

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,4 @@ install:
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - "%LOCALAPPDATA%/atom/bin/apm test --path %LOCALAPPDATA%/atom/bin/atom.cmd"
+  - "%LOCALAPPDATA%/atom/bin/apm test --one --path %LOCALAPPDATA%/atom/bin/atom.cmd"

--- a/build-package.sh
+++ b/build-package.sh
@@ -39,6 +39,6 @@ if [ -f ./node_modules/.bin/coffeelint ]; then
 fi
 
 echo "Running specs..."
-ATOM_PATH=./atom atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm test --path atom/Atom.app/Contents/Resources/app/atom.sh
+ATOM_PATH=./atom atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm test --one --path atom/Atom.app/Contents/Resources/app/atom.sh
 
 exit


### PR DESCRIPTION
This adds `--one` to the `apm test` command so that specs run in 1.0 API preview mode.

This shipped with Atom 0.197 so I'd like to ship it here now so builds start failing if deprecated APIs are used for packages using CI.

http://blog.atom.io/2015/05/01/removing-deprecated-apis.html

Thoughts @atom/feedback ?