### PR TITLE
Limit standard lint directories

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -52,9 +52,16 @@ if [ -f ./node_modules/.bin/eslint ]; then
 fi
 
 if [ -f ./node_modules/.bin/standard ]; then
-  echo "Linting package with standard..."
-  ./node_modules/.bin/standard
-  rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+  if [ -d ./lib ]; then
+    echo "Linting package..."
+    ./node_modules/.bin/standard lib
+    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+  fi
+  if [ -d ./spec ]; then
+    echo "Linting package specs..."
+    ./node_modules/.bin/standard spec
+    rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+  fi
 fi
 
 echo "Running specs..."


### PR DESCRIPTION
As it is implemented now, the standard linter will go trough all directories except node_modules/**, *.min.js, bundle.js, coverage/** and hidden files/directories. This means it will go into the atom directory and lint the atom js code:

```
Linting package with standard...
standard: Use JavaScript Standard Style (https://github.com/feross/standard)
  /Users/travis/build/markushedvall/plantuml-viewer/atom/Atom.app/Contents/Resources/app/apm/lib/apm-cli.js:1:9: Missing space before function parentheses.
```

I made it so it behaves similar to the other linters, only linting the lib and spec directories. Another option would be to rename the atom folder to .atom so that it is hidden.