### PR TITLE
Use glob instead of directory when linting with standard

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -54,12 +54,12 @@ fi
 if [ -f ./node_modules/.bin/standard ]; then
   if [ -d ./lib ]; then
     echo "Linting package..."
-    ./node_modules/.bin/standard lib
+    ./node_modules/.bin/standard lib/**/*.js
     rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
   fi
   if [ -d ./spec ]; then
     echo "Linting package specs..."
-    ./node_modules/.bin/standard spec
+    ./node_modules/.bin/standard spec/**/*.js
     rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
   fi
 fi


### PR DESCRIPTION
Refs https://github.com/atom/toggle-quotes/pull/26#issuecomment-135603697
Refs https://github.com/feross/standard/issues/135

/cc @maxbrunsfeld 