### PR TITLE
Add Linux CI On Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: objective-c
-
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 git:
   depth: 10
 
-sudo: required
+sudo: false
 
 os:
   - linux
@@ -21,3 +21,11 @@ env:
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,17 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 git:
   depth: 10
+
+sudo: required
+
+os:
+  - linux
+  - osx
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta

--- a/build-package.sh
+++ b/build-package.sh
@@ -7,7 +7,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     curl -s -L "https://atom.io/download/mac?channel=$ATOM_CHANNEL" \
       -H 'Accept: application/octet-stream' \
       -o "atom.zip"
-    ATOM_DOWNLOAD_URL="https://atom.io/download/mac?channel=$ATOM_CHANNEL"
     mkdir atom
     unzip -q atom.zip -d atom
     if [ "$ATOM_CHANNEL" == "stable" ]; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -2,83 +2,62 @@
 
 echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
-[ "$TRAVIS_OS_NAME" == "osx" ] && ATOM_DOWNLOAD_URL="https://atom.io/download/mac?channel=$ATOM_CHANNEL" || ATOM_DOWNLOAD_URL="https://atom.io/download/deb?channel=$ATOM_CHANNEL"
-[ "$TRAVIS_OS_NAME" == "osx" ] && ATOM_DOWNLOAD_FILE=atom.zip || ATOM_DOWNLOAD_FILE=atom.deb
 
-curl -s -L "$ATOM_DOWNLOAD_URL" \
-  -H 'Accept: application/octet-stream' \
-  -o "$ATOM_DOWNLOAD_FILE"
-
-if [ "$TRAVIS_OS_NAME" == "osx" ]
-then
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    curl -s -L "https://atom.io/download/mac?channel=$ATOM_CHANNEL" \
+      -H 'Accept: application/octet-stream' \
+      -o "atom.zip"
+    ATOM_DOWNLOAD_URL="https://atom.io/download/mac?channel=$ATOM_CHANNEL"
     mkdir atom
     unzip -q atom.zip -d atom
-    if [ "$ATOM_CHANNEL" == "stable" ]
-    then
-      export CI_ATOM_APPNAME="Atom.app"
-      export CI_ATOM_SCRIPTNAME="atom.sh"
-      export CI_ATOM_SH="./atom/${CI_ATOM_APPNAME}/Contents/Resources/app/atom.sh"
+    if [ "$ATOM_CHANNEL" == "stable" ]; then
+      export ATOM_APP_NAME="Atom.app"
+      export ATOM_SCRIPT_NAME="atom.sh"
+      export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
     else
       export ATOM_CHANNEL_CAMELCASE="$(tr '[:lower:]' '[:upper:]' <<< ${ATOM_CHANNEL:0:1})${ATOM_CHANNEL:1}"
-      export CI_ATOM_APPNAME="Atom ${ATOM_CHANNEL_CAMELCASE}.app"
-      export CI_ATOM_SCRIPTNAME="atom-${ATOM_CHANNEL}"
-      export CI_ATOM_SH="./atom-${ATOM_CHANNEL}"
-      ln -s "./atom/${CI_ATOM_APPNAME}/Contents/Resources/app/atom.sh" "${CI_ATOM_SH}"
+      export ATOM_APP_NAME="Atom ${ATOM_CHANNEL_CAMELCASE}.app"
+      export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+      export ATOM_SCRIPT_PATH="./atom-${ATOM_CHANNEL}"
+      ln -s "./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
     fi
-    export PATH="$PWD/atom/${CI_ATOM_APPNAME}/Contents/Resources/app/apm/bin:$PATH"
+    export PATH="$PWD/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:$PATH"
     export ATOM_PATH="./atom"
-    export CI_APM_SH="./atom/${CI_ATOM_APPNAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+    export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
 else
+    curl -s -L "https://atom.io/download/deb?channel=$ATOM_CHANNEL" \
+      -H 'Accept: application/octet-stream' \
+      -o "atom.deb"
     /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     export DISPLAY=":99"
-    sudo apt-get update -qq
-    sudo apt-get install build-essential -qq
-    sudo apt-get install git -qq
-    sudo apt-get install libgnome-keyring-dev -qq
-    sudo apt-get install fakeroot -qq
-    sudo apt-get install gconf2 -qq
-    sudo apt-get install gconf-service -qq
-    sudo apt-get install libgtk2.0-0 -qq
-    sudo apt-get install libudev1 -qq
-    sudo apt-get install libgcrypt20 -qq
-    sudo apt-get install libnotify4 -qq
-    sudo apt-get install libxtst6 -qq
-    sudo apt-get install libnss3 -qq
-    sudo apt-get install python -qq
-    sudo apt-get install gvfs-bin -qq
-    sudo apt-get install xdg-utils -qq
-    sudo apt-get install libcap2 -qq
-    sudo apt-get install gdebi-core -qq
-    sudo apt-get update -qq
-    sudo gdebi -n atom.deb
-    if [ "$ATOM_CHANNEL" == "stable" ]
-    then
-      export CI_ATOM_SCRIPTNAME="atom"
-      export CI_APM_SCRIPTNAME="apm"
+    dpkg-deb -x atom.deb "$HOME/atom"
+    if [ "$ATOM_CHANNEL" == "stable" ]; then
+      export ATOM_SCRIPT_NAME="atom"
+      export APM_SCRIPT_NAME="apm"
     else
-      export CI_ATOM_SCRIPTNAME="atom-$ATOM_CHANNEL"
-      export CI_APM_SCRIPTNAME="apm-$ATOM_CHANNEL"
+      export ATOM_SCRIPT_NAME="atom-$ATOM_CHANNEL"
+      export APM_SCRIPT_NAME="apm-$ATOM_CHANNEL"
     fi
-    export CI_ATOM_SH="/usr/bin/$CI_ATOM_SCRIPTNAME"
-    export CI_APM_SH="/usr/bin/$CI_APM_SCRIPTNAME"
+    export ATOM_SCRIPT_PATH="$HOME/atom/usr/bin/$ATOM_SCRIPT_NAME"
+    export APM_SCRIPT_PATH="$HOME/atom/usr/bin/$APM_SCRIPT_NAME"
 fi
 
 
 echo "Using Atom version:"
-/bin/bash "$CI_ATOM_SH" -v
+"$ATOM_SCRIPT_PATH" -v
 echo "Using APM version:"
-/bin/bash "$CI_APM_SH" -v
+"$APM_SCRIPT_PATH" -v
 
 echo "Downloading package dependencies..."
-/bin/bash "$CI_APM_SH" clean
-/bin/bash "$CI_APM_SH" install
+"$APM_SCRIPT_PATH" clean
+"$APM_SCRIPT_PATH" install
 
 TEST_PACKAGES="${APM_TEST_PACKAGES:=none}"
 
 if [ "$TEST_PACKAGES" != "none" ]; then
   echo "Installing atom package dependencies..."
   for pack in $TEST_PACKAGES ; do
-    /bin/bash "$CI_APM_SH" install $pack
+    "$APM_SCRIPT_PATH" install $pack
   done
 fi
 
@@ -122,5 +101,5 @@ if [ -f ./node_modules/.bin/standard ]; then
 fi
 
 echo "Running specs..."
-/bin/bash "$CI_ATOM_SH" --test spec
+"$ATOM_SCRIPT_PATH" --test spec
 exit

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,27 +1,84 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Downloading latest Atom release..."
-curl -s -L "https://atom.io/download/mac" \
-  -H 'Accept: application/octet-stream' \
-  -o atom.zip
+ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
+[ "$TRAVIS_OS_NAME" == "osx" ] && ATOM_DOWNLOAD_URL="https://atom.io/download/mac?channel=$ATOM_CHANNEL" || ATOM_DOWNLOAD_URL="https://atom.io/download/deb?channel=$ATOM_CHANNEL"
+[ "$TRAVIS_OS_NAME" == "osx" ] && ATOM_DOWNLOAD_FILE=atom.zip || ATOM_DOWNLOAD_FILE=atom.deb
 
-mkdir atom
-unzip -q atom.zip -d atom
-export PATH=$PWD/atom/Atom.app/Contents/Resources/app/apm/bin:$PATH
+curl -s -L "$ATOM_DOWNLOAD_URL" \
+  -H 'Accept: application/octet-stream' \
+  -o "$ATOM_DOWNLOAD_FILE"
+
+if [ "$TRAVIS_OS_NAME" == "osx" ]
+then
+    mkdir atom
+    unzip -q atom.zip -d atom
+    if [ "$ATOM_CHANNEL" == "stable" ]
+    then
+      export CI_ATOM_APPNAME="Atom.app"
+      export CI_ATOM_SCRIPTNAME="atom.sh"
+      export CI_ATOM_SH="./atom/${CI_ATOM_APPNAME}/Contents/Resources/app/atom.sh"
+    else
+      export ATOM_CHANNEL_CAMELCASE="$(tr '[:lower:]' '[:upper:]' <<< ${ATOM_CHANNEL:0:1})${ATOM_CHANNEL:1}"
+      export CI_ATOM_APPNAME="Atom ${ATOM_CHANNEL_CAMELCASE}.app"
+      export CI_ATOM_SCRIPTNAME="atom-${ATOM_CHANNEL}"
+      export CI_ATOM_SH="./atom-${ATOM_CHANNEL}"
+      ln -s "./atom/${CI_ATOM_APPNAME}/Contents/Resources/app/atom.sh" "${CI_ATOM_SH}"
+    fi
+    export PATH="$PWD/atom/${CI_ATOM_APPNAME}/Contents/Resources/app/apm/bin:$PATH"
+    export ATOM_PATH="./atom"
+    export CI_APM_SH="./atom/${CI_ATOM_APPNAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+else
+    /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+    export DISPLAY=":99"
+    sudo apt-get update -qq
+    sudo apt-get install build-essential -qq
+    sudo apt-get install git -qq
+    sudo apt-get install libgnome-keyring-dev -qq
+    sudo apt-get install fakeroot -qq
+    sudo apt-get install gconf2 -qq
+    sudo apt-get install gconf-service -qq
+    sudo apt-get install libgtk2.0-0 -qq
+    sudo apt-get install libudev1 -qq
+    sudo apt-get install libgcrypt20 -qq
+    sudo apt-get install libnotify4 -qq
+    sudo apt-get install libxtst6 -qq
+    sudo apt-get install libnss3 -qq
+    sudo apt-get install python -qq
+    sudo apt-get install gvfs-bin -qq
+    sudo apt-get install xdg-utils -qq
+    sudo apt-get install libcap2 -qq
+    sudo apt-get install gdebi-core -qq
+    sudo apt-get update -qq
+    sudo gdebi -n atom.deb
+    if [ "$ATOM_CHANNEL" == "stable" ]
+    then
+      export CI_ATOM_SCRIPTNAME="atom"
+      export CI_APM_SCRIPTNAME="apm"
+    else
+      export CI_ATOM_SCRIPTNAME="atom-$ATOM_CHANNEL"
+      export CI_APM_SCRIPTNAME="apm-$ATOM_CHANNEL"
+    fi
+    export CI_ATOM_SH="/usr/bin/$CI_ATOM_SCRIPTNAME"
+    export CI_APM_SH="/usr/bin/$CI_APM_SCRIPTNAME"
+fi
+
 
 echo "Using Atom version:"
-ATOM_PATH=./atom ./atom/Atom.app/Contents/Resources/app/atom.sh -v
+/bin/bash "$CI_ATOM_SH" -v
+echo "Using APM version:"
+/bin/bash "$CI_APM_SH" -v
 
 echo "Downloading package dependencies..."
-atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm clean
-atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install
+/bin/bash "$CI_APM_SH" clean
+/bin/bash "$CI_APM_SH" install
 
 TEST_PACKAGES="${APM_TEST_PACKAGES:=none}"
 
 if [ "$TEST_PACKAGES" != "none" ]; then
   echo "Installing atom package dependencies..."
   for pack in $TEST_PACKAGES ; do
-    atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm install $pack
+    /bin/bash "$CI_APM_SH" install $pack
   done
 fi
 
@@ -65,6 +122,5 @@ if [ -f ./node_modules/.bin/standard ]; then
 fi
 
 echo "Running specs..."
-ATOM_PATH=./atom atom/Atom.app/Contents/Resources/app/apm/node_modules/.bin/apm test --path atom/Atom.app/Contents/Resources/app/atom.sh
-
+/bin/bash "$CI_ATOM_SH" --test spec
 exit


### PR DESCRIPTION
This PR:

- [x] Updates .travis.yml to include a build matrix for linux and osx
- [x] Updates .travis.yml to include a build matrix for stable and beta channels
- [x] Updates build-package.sh to work when the OS is linux
- [x] Updates build-package.sh to work with a variable number of channels (i.e. if additional channels are added (e.g. `alpha`) then it should Just Work™
- [x] Fixes #2

In the future, further enhancement could be possible on Linux if there were a .deb repository for atom's .deb releases:

- [ ] Update `sudo: true` to be `sudo: false` to use Travis' container based infrastructure
- [ ] Submit atom's .deb repository to https://github.com/travis-ci/apt-package-whitelist
- [ ] Remove individual package installation, and switch to:
```
addons:
  apt:
    packages:
    - atom
```

/cc @nathansobo @kevinsawicki @thedaniel 