### PR TITLE
Update ClircleCI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,9 @@
 dependencies:
-    pre:
-        - wget -O atom-amd64.deb https://atom.io/download/deb
-        - sudo dpkg --install atom-amd64.deb || true
-        - sudo apt-get -f install
-        - apm install
+  override:
+    - wget -O atom-amd64.deb https://atom.io/download/deb
+    - sudo dpkg --install atom-amd64.deb || true
+    - sudo apt-get -f install
+    - apm install
 test:
   override:
     - apm test


### PR DESCRIPTION
Fix the indentation of the first section.
Change to override on the dependencies, the inferred options just duplicate the work (running `npm install` after we run `apm install`).