### PR TITLE
Use curl Instead Of wget

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - wget -O atom-amd64.deb https://atom.io/download/deb
+    - curl -L https://atom.io/download/deb -o atom-amd64.deb
     - sudo dpkg --install atom-amd64.deb || true
     - sudo apt-get -f install
     - apm install


### PR DESCRIPTION
I recently got error with wget, I changed wget to curl. Please refer to my ci logs.

wget: https://circleci.com/gh/kn1kn1/language-context-free/106
curl: https://circleci.com/gh/kn1kn1/language-context-free/108