### PR TITLE
In CI Templates, Restrict Builds To The master Branch And PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,7 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
Without it we get 5 instead of 3 builds on every PR opened from the same repo
cc @Arcanemagus 