### PR TITLE
Force apt database update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ dependencies:
   override:
     - curl -L https://atom.io/download/deb -o atom-amd64.deb
     - sudo dpkg --install atom-amd64.deb || true
+    - sudo apt-get update
     - sudo apt-get -f install
     - apm install
 test:


### PR DESCRIPTION
Not all mirrors are keeping around the old package versions the database on the CircleCI container is expecting, force an update to the current state.

See an example of a build failing due to a 404 on a package here: https://circleci.com/gh/AtomLinter/linter-eslint/292

This issue has only affected a few builds so far, but will get worse and worse as the mirrors diverge more from what the old database on the CircleCI containers is expecting.