### PR TITLE
Set ATOM_ACCESS_TOKEN If It Is Not Already Set

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,6 +1,14 @@
 Set-StrictMode -Version Latest
 $script:PACKAGE_FOLDER = "$env:APPVEYOR_BUILD_FOLDER"
 Set-Location $script:PACKAGE_FOLDER
+
+if ($env:ATOM_ACCESS_TOKEN -and ($env:ATOM_ACCESS_TOKEN.trim() -ne "")) {
+  # Yay!
+} else {
+  $env:ATOM_ACCESS_TOKEN = "da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4"
+  [Environment]::SetEnvironmentVariable("ATOM_ACCESS_TOKEN", "da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4", "User")
+}
+
 $script:ATOM_CHANNEL = "stable"
 $script:ATOM_DIRECTORY_NAME = "Atom"
 if ($env:ATOM_CHANNEL -and ($env:ATOM_CHANNEL.tolower() -ne "stable")) {

--- a/build-package.sh
+++ b/build-package.sh
@@ -2,6 +2,10 @@
 
 echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
+ACCESS_TOKEN_CHECK="$ATOM_ACCESS_TOKEN:=unset"
+if [ "$ACCESS_TOKEN_CHECK" = "unset" ]; then
+  export ATOM_ACCESS_TOKEN="da809a6077bb1b0aa7c5623f7b2d5f1fec2faae4"
+fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     curl -s -L "https://atom.io/download/mac?channel=$ATOM_CHANNEL" \


### PR DESCRIPTION
This PR sets ATOM_ACCESS_TOKEN if the user hasn't already set it in their CI configuration. This has the effect of preventing rate limiting when using apm to install packages.

- Fixes #39