### PR TITLE
Don't modify PATH on OS X

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -19,7 +19,6 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       export ATOM_SCRIPT_PATH="./atom-${ATOM_CHANNEL}"
       ln -s "./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
     fi
-    export PATH="$PWD/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:$PATH"
     export ATOM_PATH="./atom"
     export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
 else


### PR DESCRIPTION
There is a node executable in the apm/bin directory, which overrides any version of Node.js installed on the system since the PATH is being updated to put this path at the front. As the Linux side of the script does not do this, remove the modification of the PATH to stop breaking Node.js.

You can see a [simplified version](https://github.com/AtomLinter/linter-htmlhint/blob/8ff7d7e73842f2e41503f4d8cea1c5c10713a9eb/x.sh) of the script being run [here](https://travis-ci.org/AtomLinter/linter-htmlhint/builds/142656364). This shows that Node.js is v6.2.2 at the start of the script, but after the `PATH` modification it shows Node.js at v0.10.40.

I'm not sure why this modification was there in the first place though, @joefitzgerald as you are the original author of that do you know if this is necessary?