### PR TITLE
Improve linter detection by using `npm ls`

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -59,8 +59,7 @@ if [ "$TEST_PACKAGES" != "none" ]; then
 fi
 
 has_linter() {
-  local result=$( npm ls --parseable --dev --depth=0 "$1" 2> /dev/null )
-  [ -n "${result}" ]
+  \npm ls --parseable --dev --depth=0 | \grep "/${1}$" > /dev/null
 }
 
 if has_linter coffeelint; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -21,24 +21,23 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
     fi
     export ATOM_PATH="./atom"
     export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+    export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
 else
     curl -s -L "https://atom.io/download/deb?channel=$ATOM_CHANNEL" \
       -H 'Accept: application/octet-stream' \
       -o "atom.deb"
     /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     export DISPLAY=":99"
-    dpkg-deb -x atom.deb "$HOME/atom"
-    if [ "$ATOM_CHANNEL" = "stable" ]; then
+    dpkg-deb -x atom.deb "${HOME}/atom"
+    if [ "${ATOM_CHANNEL}" = "stable" ]; then
       export ATOM_SCRIPT_NAME="atom"
-      export APM_SCRIPT_NAME="apm"
     else
-      export ATOM_SCRIPT_NAME="atom-$ATOM_CHANNEL"
-      export APM_SCRIPT_NAME="apm-$ATOM_CHANNEL"
+      export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
     fi
-    export ATOM_SCRIPT_PATH="$HOME/atom/usr/bin/$ATOM_SCRIPT_NAME"
-    export APM_SCRIPT_PATH="$HOME/atom/usr/bin/$APM_SCRIPT_NAME"
+    export ATOM_SCRIPT_PATH="${HOME}/atom/usr/bin/${ATOM_SCRIPT_NAME}"
+    export APM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/apm"
+    export NPM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/npm"
 fi
-
 
 echo "Using Atom version:"
 "$ATOM_SCRIPT_PATH" -v
@@ -59,7 +58,8 @@ if [ "$TEST_PACKAGES" != "none" ]; then
 fi
 
 has_linter() {
-  npm ls --parseable --dev --depth=0 | grep "/${1}$" > /dev/null
+  local result=$( "${NPM_SCRIPT_PATH}" ls --parseable --dev --depth=0 "${name}" 2> /dev/null )
+  [ -n "${result}" ]
 }
 
 if has_linter coffeelint; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -59,7 +59,8 @@ if [ "$TEST_PACKAGES" != "none" ]; then
 fi
 
 has_linter() {
-  \npm ls --parseable --dev --depth=0 | \grep "/${1}$" > /dev/null
+  local result=$( npm ls --parseable --dev --depth=0 "$1" 2> /dev/null )
+  [ -n "${result}" ]
 }
 
 if has_linter coffeelint; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -58,7 +58,11 @@ if [ "$TEST_PACKAGES" != "none" ]; then
   done
 fi
 
-if [ -f ./node_modules/.bin/coffeelint ]; then
+use_linter() {
+  \npm ls --parseable --dev --depth=0 | \grep "/${1}$" &> /dev/null
+}
+
+if [ use_linter coffeelint ]; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/coffeelint lib
@@ -71,7 +75,7 @@ if [ -f ./node_modules/.bin/coffeelint ]; then
   fi
 fi
 
-if [ -f ./node_modules/.bin/eslint ]; then
+if [ use_linter eslint ]; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/eslint lib
@@ -84,7 +88,7 @@ if [ -f ./node_modules/.bin/eslint ]; then
   fi
 fi
 
-if [ -f ./node_modules/.bin/standard ]; then
+if [ use_linter standard ]; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/standard "lib/**/*.js"

--- a/build-package.sh
+++ b/build-package.sh
@@ -62,7 +62,7 @@ use_linter() {
   \npm ls --parseable --dev --depth=0 | \grep "/${1}$" &> /dev/null
 }
 
-if [ use_linter coffeelint ]; then
+if use_linter coffeelint; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/coffeelint lib
@@ -75,7 +75,7 @@ if [ use_linter coffeelint ]; then
   fi
 fi
 
-if [ use_linter eslint ]; then
+if use_linter eslint; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/eslint lib
@@ -88,7 +88,7 @@ if [ use_linter eslint ]; then
   fi
 fi
 
-if [ use_linter standard ]; then
+if use_linter standard; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/standard "lib/**/*.js"

--- a/build-package.sh
+++ b/build-package.sh
@@ -59,7 +59,7 @@ if [ "$TEST_PACKAGES" != "none" ]; then
 fi
 
 use_linter() {
-  \npm ls --parseable --dev --depth=0 | \grep "/${1}$" &> /dev/null
+  \npm ls --parseable --dev --depth=0 | \grep "/${1}$" > /dev/null
 }
 
 if use_linter coffeelint; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -58,11 +58,11 @@ if [ "$TEST_PACKAGES" != "none" ]; then
   done
 fi
 
-use_linter() {
+has_linter() {
   \npm ls --parseable --dev --depth=0 | \grep "/${1}$" > /dev/null
 }
 
-if use_linter coffeelint; then
+if has_linter coffeelint; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/coffeelint lib
@@ -75,7 +75,7 @@ if use_linter coffeelint; then
   fi
 fi
 
-if use_linter eslint; then
+if has_linter eslint; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/eslint lib
@@ -88,7 +88,7 @@ if use_linter eslint; then
   fi
 fi
 
-if use_linter standard; then
+if has_linter standard; then
   if [ -d ./lib ]; then
     echo "Linting package..."
     ./node_modules/.bin/standard "lib/**/*.js"

--- a/build-package.sh
+++ b/build-package.sh
@@ -59,7 +59,7 @@ if [ "$TEST_PACKAGES" != "none" ]; then
 fi
 
 has_linter() {
-  \npm ls --parseable --dev --depth=0 | \grep "/${1}$" > /dev/null
+  npm ls --parseable --dev --depth=0 | grep "/${1}$" > /dev/null
 }
 
 if has_linter coffeelint; then


### PR DESCRIPTION
This PR hopefully resolves the linter detection bug triggered by npm v3; checking the presence of binaries in `./node_modules/.bin` is problematic when using `standard` since it uses `eslint`, thus we end up thinking we're supposed to lint using `eslint` due to the precedence/order of binary checks.

The new technique simply involves combing `npm ls` with a simple `grep` check.

/cc @atom/feedback @maxbrunsfeld 

---
- [x] Patch `build-package.sh`
- [ ] Patch `build-package.ps1`