### PR TITLE
Remove requirement for `spec` directory

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -169,15 +169,13 @@ function RunLinters() {
 function RunSpecs() {
     $specpath = "$script:PACKAGE_FOLDER\spec"
     $specpathexists = Test-Path $specpath
-    if (!$specpathexists) {
-        Write-Host "Missing spec folder! Please consider adding a test suite in '.\spec'"
-        ExitWithCode -exitcode 1
-    }
-    Write-Host "Running specs..."
-    & "$script:ATOM_EXE_PATH" --test spec 2>&1 | %{ "$_" }
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "Specs Failed"
-        ExitWithCode -exitcode $LASTEXITCODE
+    if ($specpathexists) {
+      Write-Host "Running specs..."
+      & "$script:ATOM_EXE_PATH" --test spec 2>&1 | %{ "$_" }
+      if ($LASTEXITCODE -ne 0) {
+          Write-Host "Specs Failed"
+          ExitWithCode -exitcode $LASTEXITCODE
+      }
     }
 }
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -100,8 +100,5 @@ fi
 if [ -d ./spec ]; then
   echo "Running specs..."
   "$ATOM_SCRIPT_PATH" --test spec
-else
-  echo "Missing spec folder! Please consider adding a test suite in `./spec`"
-  exit 1
 fi
 exit


### PR DESCRIPTION
Since atom/atom#8968, it’s now possible to run tests without the
Jasmine harness.  Instead, through by running `atom --test test.js`,
and an `atomTestRunner` property in `package.json` which handles
those files.  However, that setup currently isn’t supported by
`atom/ci`.

This update removes the requirement for a `./spec` folder, instead
requiring users of `atom/ci` to specify their tests in the `travis`
`script` property, like so:

```yaml
script:
- curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
- atom --test test.js
```

Current behaviour, if `./spec` is found, remains the same.