### PR TITLE
Optionally lint using the system Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ os:
 env:
   global:
     - APM_TEST_PACKAGES=""
+    - ATOM_LINT_WITH_BUNDLED_NODE="false"
 
   matrix:
     - ATOM_CHANNEL=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ notifications:
 
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
+# Needed to disable the auto-install step running `npm install`
+install: true
+
 git:
   depth: 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Installed for linting the project
+language: node_js
+node_js: "6"
+
 notifications:
   email:
     on_success: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
   - ATOM_CHANNEL: beta
 
 install:
-  - ps: Install-Product node 5
+  - ps: Install-Product node 6
 
 build_script:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ skip_tags: true
 
 environment:
   APM_TEST_PACKAGES:
+  ATOM_LINT_WITH_BUNDLED_NODE: "false"
 
   matrix:
   - ATOM_CHANNEL: stable

--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,7 @@ dependencies:
 test:
   override:
     - apm test
+
+machine:
+  node:
+    version: 6


### PR DESCRIPTION
This PR makes a few changes:

* Installs Node.js v6 on all platforms by default
* ~~Only test the beta channel on Linux on the Travis-CI builds, due to the limited capacity of the Travis-CI OSX infrastructure~~
* Introduces a new environment variable `ATOM_LINT_WITH_BUNDLED_NODE`, which controls whether the `node` bundled with APM is used, or the system `node` is used to install and run the linters
* ~~Moves CircleCI to using the script~~ (#50)

This is a slightly different approach from the workaround that has been being tested on the linter packages, so some more testing needs to be done to ensure this is working properly.

Some aspects of this may be better split into separate PRs (like moving CircleCI to the script), if there is anything that you want split out just let me know.