### PR TITLE
Move CircleCI to using the build_script.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ can run `apm help test` to learn more about that command.
 #### Travis CI
 
 The `.travis.yml` template downloads the [build-package.sh](https://raw.githubusercontent.com/atom/ci/master/build-package.sh)
-from this repository. This script then downloads node, the latest Atom release,
-and runs the `apm test` command to run your package's specs.
+from this repository. This script then downloads the latest Atom release,
+installs your package's dependencies, and runs the `apm test` command to run
+your package's specs.
 
 #### Appveyor
 
@@ -75,8 +76,7 @@ package's specs.
 
 #### CircleCI
 
-The `circle.yml` template downloads the [latest version of Atom](https://atom.io/download/deb) for Ubuntu and installs it using apt. `apm install` is run in your package directory to ensure any node dependencies
-are available. Finally, the script runs the `apm test` command to run your package's specs.
+The `circle.yml` template runs the same script that is used in the Travis-CI builds.
 
 
 ### What does the output look like?
@@ -87,6 +87,5 @@ are available. Finally, the script runs the `apm test` command to run your packa
 
 ### What packages use this?
 
-* [OS X and Ubuntu Linux @ Travis CI](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
+* [OS X and Ubuntu Linux @ Travis CI and CircleCI](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
 * [Windows @ Appveyor](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)
-* [Ubuntu Linux @ CircleCI](https://github.com/search?utf8=%E2%9C%93&q=%22https%3A%2F%2Fatom.io%2Fdownload%2Fdeb%22+filename%3Acircle.yml&type=Code)

--- a/build-package.sh
+++ b/build-package.sh
@@ -22,7 +22,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
   export ATOM_PATH="./atom"
   export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
   export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
-elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
+elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
   curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
     -H 'Accept: application/octet-stream' \
     -o "atom-amd64.deb"
@@ -39,8 +39,8 @@ elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
   export ATOM_SCRIPT_PATH="${HOME}/atom/usr/bin/${ATOM_SCRIPT_NAME}"
   export APM_SCRIPT_PATH="${HOME}/atom/usr/bin/${APM_SCRIPT_NAME}"
   export NPM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/npm"
-elif [ "$CIRCLECI" = "true" ]; then
-  curl -s -L "https://atom.io/download/deb?channel=$ATOM_CHANNEL" \
+elif [ "${CIRCLECI}" = "true" ]; then
+  curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
     -H 'Accept: application/octet-stream' \
     -o "atom-amd64.deb"
   sudo dpkg --install atom-amd64.deb || true
@@ -67,9 +67,9 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   # Override the PATH to put the Node bundled with APM first
   if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
-  elif [ "$CIRCLECI" = "true" ]; then
+  elif [ "${CIRCLECI}" = "true" ]; then
     # Since CircleCI is a fully installed environment, we use the system path to apm
-    export PATH="/usr/share/atom/resources/app/apm/bin:$PATH"
+    export PATH="/usr/share/atom/resources/app/apm/bin:${PATH}"
   else
     export PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/bin:${PATH}"
   fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -22,13 +22,13 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     export ATOM_PATH="./atom"
     export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
     export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
-else
+elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
     curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
       -H 'Accept: application/octet-stream' \
-      -o "atom.deb"
+      -o "atom-amd64.deb"
     /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     export DISPLAY=":99"
-    dpkg-deb -x atom.deb "${HOME}/atom"
+    dpkg-deb -x atom-amd64.deb "${HOME}/atom"
     if [ "${ATOM_CHANNEL}" = "stable" ]; then
       export ATOM_SCRIPT_NAME="atom"
       export APM_SCRIPT_NAME="apm"
@@ -39,8 +39,19 @@ else
     export ATOM_SCRIPT_PATH="${HOME}/atom/usr/bin/${ATOM_SCRIPT_NAME}"
     export APM_SCRIPT_PATH="${HOME}/atom/usr/bin/${APM_SCRIPT_NAME}"
     export NPM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/npm"
+elif [ "$CIRCLECI" = "true" ]; then
+  curl -s -L "https://atom.io/download/deb?channel=$ATOM_CHANNEL" \
+    -H 'Accept: application/octet-stream' \
+    -o "atom-amd64.deb"
+  sudo dpkg --install atom-amd64.deb || true
+  sudo apt-get update
+  sudo apt-get -f install
+  export ATOM_SCRIPT_PATH="atom"
+  export APM_SCRIPT_PATH="apm"
+else
+  echo "Unknown CI environment, exiting!"
+  exit 1
 fi
-
 
 echo "Using Atom version:"
 "${ATOM_SCRIPT_PATH}" -v
@@ -56,6 +67,9 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   # Override the PATH to put the Node bundled with APM first
   if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
+  elif [ "$CIRCLECI" = "true" ]; then
+    # Since CircleCI is a fully installed environment, we use the system path to apm
+    export PATH="/usr/share/atom/resources/app/apm/bin:$PATH"
   else
     export PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/bin:${PATH}"
   fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -4,41 +4,41 @@ echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 
 if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-    curl -s -L "https://atom.io/download/mac?channel=${ATOM_CHANNEL}" \
-      -H 'Accept: application/octet-stream' \
-      -o "atom.zip"
-    mkdir atom
-    unzip -q atom.zip -d atom
-    if [ "${ATOM_CHANNEL}" = "stable" ]; then
-      export ATOM_APP_NAME="Atom.app"
-      export ATOM_SCRIPT_NAME="atom.sh"
-      export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
-    else
-      export ATOM_APP_NAME="Atom ${ATOM_CHANNEL}.app"
-      export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
-      export ATOM_SCRIPT_PATH="./atom-${ATOM_CHANNEL}"
-      ln -s "./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
-    fi
-    export ATOM_PATH="./atom"
-    export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
-    export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
+  curl -s -L "https://atom.io/download/mac?channel=${ATOM_CHANNEL}" \
+    -H 'Accept: application/octet-stream' \
+    -o "atom.zip"
+  mkdir atom
+  unzip -q atom.zip -d atom
+  if [ "${ATOM_CHANNEL}" = "stable" ]; then
+    export ATOM_APP_NAME="Atom.app"
+    export ATOM_SCRIPT_NAME="atom.sh"
+    export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
+  else
+    export ATOM_APP_NAME="Atom ${ATOM_CHANNEL}.app"
+    export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+    export ATOM_SCRIPT_PATH="./atom-${ATOM_CHANNEL}"
+    ln -s "./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
+  fi
+  export ATOM_PATH="./atom"
+  export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+  export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
 elif [ "$TRAVIS_OS_NAME" = "linux" ]; then
-    curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
-      -H 'Accept: application/octet-stream' \
-      -o "atom-amd64.deb"
-    /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
-    export DISPLAY=":99"
-    dpkg-deb -x atom-amd64.deb "${HOME}/atom"
-    if [ "${ATOM_CHANNEL}" = "stable" ]; then
-      export ATOM_SCRIPT_NAME="atom"
-      export APM_SCRIPT_NAME="apm"
-    else
-      export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
-      export APM_SCRIPT_NAME="apm-${ATOM_CHANNEL}"
-    fi
-    export ATOM_SCRIPT_PATH="${HOME}/atom/usr/bin/${ATOM_SCRIPT_NAME}"
-    export APM_SCRIPT_PATH="${HOME}/atom/usr/bin/${APM_SCRIPT_NAME}"
-    export NPM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/npm"
+  curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
+    -H 'Accept: application/octet-stream' \
+    -o "atom-amd64.deb"
+  /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
+  export DISPLAY=":99"
+  dpkg-deb -x atom-amd64.deb "${HOME}/atom"
+  if [ "${ATOM_CHANNEL}" = "stable" ]; then
+    export ATOM_SCRIPT_NAME="atom"
+    export APM_SCRIPT_NAME="apm"
+  else
+    export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+    export APM_SCRIPT_NAME="apm-${ATOM_CHANNEL}"
+  fi
+  export ATOM_SCRIPT_PATH="${HOME}/atom/usr/bin/${ATOM_SCRIPT_NAME}"
+  export APM_SCRIPT_PATH="${HOME}/atom/usr/bin/${APM_SCRIPT_NAME}"
+  export NPM_SCRIPT_PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/node_modules/.bin/npm"
 elif [ "$CIRCLECI" = "true" ]; then
   curl -s -L "https://atom.io/download/deb?channel=$ATOM_CHANNEL" \
     -H 'Accept: application/octet-stream' \

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,12 @@ test:
 
 dependencies:
   override:
+    # If nothing is put here, CircleCI will run `npm install` using the system Node.js
     - echo "Managed in the script"
 
 machine:
   node:
     version: 6
   environment:
-    ATOM_LINT_WITH_BUNDLED_NODE: "false"
+    ATOM_LINT_WITH_BUNDLED_NODE: "true"
     APM_TEST_PACKAGES: ""

--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,6 @@ dependencies:
     - echo "Managed in the script"
 
 machine:
-  node:
-    version: 6
   environment:
     ATOM_LINT_WITH_BUNDLED_NODE: "true"
     APM_TEST_PACKAGES: ""

--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,14 @@
-dependencies:
-  override:
-    - curl -L https://atom.io/download/deb -o atom-amd64.deb
-    - sudo dpkg --install atom-amd64.deb || true
-    - sudo apt-get update
-    - sudo apt-get -f install
-    - apm clean
-    - apm install
-
 test:
   override:
-    - atom -v
-    - apm -v
-    - apm test
+    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
+
+dependencies:
+  override:
+    - echo "Managed in the script"
 
 machine:
   node:
     version: 6
+  environment:
+    ATOM_LINT_WITH_BUNDLED_NODE: "false"
+    APM_TEST_PACKAGES: ""


### PR DESCRIPTION
Move CircleCI builds to using the same script that the Travis-CI builds are using.

Successful CircleCI build here: https://circleci.com/gh/AtomLinter/linter-stylelint/496