### PR TITLE
Only Lint With Top-Level Linter Dependencies

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -114,7 +114,6 @@ function HasLinter([String] $LinterName) {
     $output = &"$script:NPM_SCRIPT_PATH" ls --parseable --dev --depth=0 $LinterName 2>$null
     if ($LastExitCode -eq 0) {
         if ($output.Trim() -ne "") {
-            Write-Host $output
             return $true
         }
     }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -15,11 +15,11 @@ $script:ATOM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\r
 $script:APM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin\apm.cmd"
 $script:NPM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\node_modules\.bin\npm.cmd"
 
-if ($env:ATOM_LINT_WITH_BUNDLED_NODE -eq "false") {
+if ($env:ATOM_LINT_WITH_BUNDLED_NODE -eq "true") {
+  $script:ATOM_LINT_WITH_BUNDLED_NODE = true
+} else {
   $script:ATOM_LINT_WITH_BUNDLED_NODE = false
   $script:NPM_SCRIPT_PATH = "npm"
-} else {
-  $script:ATOM_LINT_WITH_BUNDLED_NODE = true
 }
 
 function DownloadAtom() {

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -13,9 +13,11 @@ if ($env:ATOM_CHANNEL -and ($env:ATOM_CHANNEL.tolower() -ne "stable")) {
 $script:ATOM_EXE_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\atom.exe"
 $script:ATOM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\cli\atom.cmd"
 $script:APM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin\apm.cmd"
+$script:NPM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\node_modules\.bin\npm.cmd"
 
 if ($env:ATOM_LINT_WITH_BUNDLED_NODE -eq "false") {
   $script:ATOM_LINT_WITH_BUNDLED_NODE = false
+  $script:NPM_SCRIPT_PATH = "npm"
 } else {
   $script:ATOM_LINT_WITH_BUNDLED_NODE = true
 }
@@ -107,6 +109,19 @@ function InstallDependencies() {
     }
 }
 
+
+function HasLinter([String] $LinterName) {
+    $output = &"$script:NPM_SCRIPT_PATH" ls --parseable --dev --depth=0 $LinterName 2>$null
+    if ($LastExitCode -eq 0) {
+        if ($output.Trim() -ne "") {
+            Write-Host $output
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function RunLinters() {
     $libpath = "$script:PACKAGE_FOLDER\lib"
     $libpathexists = Test-Path $libpath
@@ -115,31 +130,31 @@ function RunLinters() {
     $specpath = "$script:PACKAGE_FOLDER\spec"
     $specpathexists = Test-Path $specpath
     $coffeelintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\coffeelint.cmd"
-    $coffeelintpathexists = Test-Path $coffeelintpath
+    $lintwithcoffeelint = HasLinter -LinterName "coffeelint"
     $eslintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\eslint.cmd"
-    $eslintpathexists = Test-Path $eslintpath
+    $lintwitheslint = HasLinter -LinterName "eslint"
     $standardpath = "$script:PACKAGE_FOLDER\node_modules\.bin\standard.cmd"
-    $standardpathexists = Test-Path $standardpath
-    if (($libpathexists -or $srcpathexists) -and ($coffeelintpathexists -or $eslintpathexists -or $standardpathexists)) {
+    $lintwithstandard = HasLinter -LinterName "standard"
+    if (($libpathexists -or $srcpathexists) -and ($lintwithcoffeelint -or $lintwitheslint -or $lintwithstandard)) {
         Write-Host "Linting package..."
     }
 
     if ($libpathexists) {
-        if ($coffeelintpathexists) {
+        if ($lintwithcoffeelint) {
             & "$coffeelintpath" lib
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }
         }
 
-        if ($eslintpathexists) {
+        if ($lintwitheslint) {
             & "$eslintpath" lib
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }
         }
 
-        if ($standardpathexists) {
+        if ($lintwithstandard) {
             & "$standardpath" lib/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -15,11 +15,11 @@ $script:ATOM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\r
 $script:APM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin\apm.cmd"
 $script:NPM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\node_modules\.bin\npm.cmd"
 
-if ($env:ATOM_LINT_WITH_BUNDLED_NODE -eq "true") {
-  $script:ATOM_LINT_WITH_BUNDLED_NODE = true
-} else {
+if ($env:ATOM_LINT_WITH_BUNDLED_NODE -eq "false") {
   $script:ATOM_LINT_WITH_BUNDLED_NODE = false
   $script:NPM_SCRIPT_PATH = "npm"
+} else {
+  $script:ATOM_LINT_WITH_BUNDLED_NODE = true
 }
 
 function DownloadAtom() {

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -163,21 +163,21 @@ function RunLinters() {
     }
 
     if ($srcpathexists) {
-        if ($coffeelintpathexists) {
+        if ($lintwithcoffeelint) {
             & "$coffeelintpath" src
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }
         }
 
-        if ($eslintpathexists) {
+        if ($lintwitheslint) {
             & "$eslintpath" src
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }
         }
 
-        if ($standardpathexists) {
+        if ($lintwithstandard) {
             & "$standardpath" src/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -185,23 +185,23 @@ function RunLinters() {
         }
     }
 
-    if ($specpathexists -and ($coffeelintpathexists -or $eslintpathexists -or $standardpathexists)) {
+    if ($specpathexists -and ($lintwithcoffeelint -or $lintwitheslint -or $lintwithstandard)) {
         Write-Host "Linting package specs..."
-        if ($coffeelintpathexists) {
+        if ($lintwithcoffeelint) {
             & "$coffeelintpath" spec
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }
         }
 
-        if ($eslintpathexists) {
+        if ($lintwitheslint) {
             & "$eslintpath" spec
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }
         }
 
-        if ($standardpathexists) {
+        if ($lintwithstandard) {
             & "$standardpath" spec/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE

--- a/build-package.sh
+++ b/build-package.sh
@@ -77,11 +77,11 @@ if [ "${TEST_PACKAGES}" != "none" ]; then
 fi
 
 has_linter() {
-  local result=$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )
+  local result="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
   [ -n "${result}" ]
 }
 
-if has_linter coffeelint; then
+if has_linter "coffeelint"; then
   if [ -d ./lib ]; then
     echo "Linting package using coffeelint..."
     ./node_modules/.bin/coffeelint lib
@@ -94,7 +94,7 @@ if has_linter coffeelint; then
   fi
 fi
 
-if has_linter eslint; then
+if has_linter "eslint"; then
   if [ -d ./lib ]; then
     echo "Linting package using eslint..."
     ./node_modules/.bin/eslint lib
@@ -107,7 +107,7 @@ if has_linter eslint; then
   fi
 fi
 
-if has_linter standard; then
+if has_linter "standard"; then
   if [ -d ./lib ]; then
     echo "Linting package using standard..."
     ./node_modules/.bin/standard "lib/**/*.js"

--- a/build-package.sh
+++ b/build-package.sh
@@ -75,7 +75,7 @@ if [ "${TEST_PACKAGES}" != "none" ]; then
   done
 fi
 
-function has_linter() {
+has_linter() {
   local result=$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )
   [ -n "${result}" ]
 }

--- a/build-package.sh
+++ b/build-package.sh
@@ -50,7 +50,7 @@ echo "Using APM version:"
 echo "Downloading package dependencies..."
 "${APM_SCRIPT_PATH}" clean
 
-ATOM_LINT_WITH_BUNDLED_NODE="${ATOM_LINT_WITH_BUNDLED_NODE:=true}"
+ATOM_LINT_WITH_BUNDLED_NODE="${ATOM_LINT_WITH_BUNDLED_NODE:=false}"
 if [ "${ATOM_LINT_WITH_BUNDLED_NODE}" = "true" ]; then
   "${APM_SCRIPT_PATH}" install
   # Override the PATH to put the Node.js bundled with APM first

--- a/build-package.sh
+++ b/build-package.sh
@@ -72,7 +72,7 @@ TEST_PACKAGES="${APM_TEST_PACKAGES:=none}"
 if [ "${TEST_PACKAGES}" != "none" ]; then
   echo "Installing atom package dependencies..."
   for pack in ${TEST_PACKAGES} ; do
-    "${APM_SCRIPT_PATH}" install "$pack"
+    "${APM_SCRIPT_PATH}" install "${pack}"
   done
 fi
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -81,15 +81,6 @@ has_linter() {
   [ -n "${result}" ]
 }
 
-echo "Testing for linters..."
-if has_linter standard; then
-  echo "Linting package with standard..."
-fi
-
-if has_linter eslint; then
-  echo "Linting package with eslint..."
-fi
-
 if has_linter coffeelint; then
   if [ -d ./lib ]; then
     echo "Linting package using coffeelint..."

--- a/build-package.sh
+++ b/build-package.sh
@@ -50,8 +50,7 @@ echo "Using APM version:"
 echo "Downloading package dependencies..."
 "${APM_SCRIPT_PATH}" clean
 
-ATOM_LINT_WITH_BUNDLED_NODE="${ATOM_LINT_WITH_BUNDLED_NODE:=true}"
-if [ "${ATOM_LINT_WITH_BUNDLED_NODE}" = "true" ]; then
+if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   "${APM_SCRIPT_PATH}" install
 
   # Override the PATH to put the Node bundled with APM first
@@ -63,8 +62,9 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE}" = "true" ]; then
 else
   export NPM_SCRIPT_PATH="npm"
   "${APM_SCRIPT_PATH}" install --production
+
   # Use the system NPM to install the devDependencies
-  echo "Using Node.js version:"
+  echo "Using Node version:"
   node --version
   echo "Using NPM version:"
   npm --version
@@ -72,11 +72,9 @@ else
   npm install
 fi
 
-TEST_PACKAGES="${APM_TEST_PACKAGES:=none}"
-
-if [ "${TEST_PACKAGES}" != "none" ]; then
+if [ -n "${APM_TEST_PACKAGES}" ]; then
   echo "Installing atom package dependencies..."
-  for pack in ${TEST_PACKAGES} ; do
+  for pack in ${APM_TEST_PACKAGES}; do
     "${APM_SCRIPT_PATH}" install "${pack}"
   done
 fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -50,7 +50,7 @@ echo "Using APM version:"
 echo "Downloading package dependencies..."
 "${APM_SCRIPT_PATH}" clean
 
-ATOM_LINT_WITH_BUNDLED_NODE="${ATOM_LINT_WITH_BUNDLED_NODE:=false}"
+ATOM_LINT_WITH_BUNDLED_NODE="${ATOM_LINT_WITH_BUNDLED_NODE:=true}"
 if [ "${ATOM_LINT_WITH_BUNDLED_NODE}" = "true" ]; then
   "${APM_SCRIPT_PATH}" install
   # Override the PATH to put the Node.js bundled with APM first

--- a/build-package.sh
+++ b/build-package.sh
@@ -53,8 +53,13 @@ echo "Downloading package dependencies..."
 ATOM_LINT_WITH_BUNDLED_NODE="${ATOM_LINT_WITH_BUNDLED_NODE:=true}"
 if [ "${ATOM_LINT_WITH_BUNDLED_NODE}" = "true" ]; then
   "${APM_SCRIPT_PATH}" install
-  # Override the PATH to put the Node.js bundled with APM first
-  export PATH="${PWD}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
+
+  # Override the PATH to put the Node bundled with APM first
+  if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+    export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
+  else
+    export PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/bin:${PATH}"
+  fi
 else
   export NPM_SCRIPT_PATH="npm"
   "${APM_SCRIPT_PATH}" install --production

--- a/build-package.sh
+++ b/build-package.sh
@@ -56,6 +56,7 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE}" = "true" ]; then
   # Override the PATH to put the Node.js bundled with APM first
   export PATH="${PWD}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
 else
+  export NPM_SCRIPT_PATH="npm"
   "${APM_SCRIPT_PATH}" install --production
   # Use the system NPM to install the devDependencies
   echo "Using Node.js version:"


### PR DESCRIPTION
This PR extends the approach used in #47, and applies it to Appveyor also.

- ~~Changes default for ATOM_LINT_WITH_BUNDLED_NODE (introduced in #49) to `false`~~
- Uses `npm ls` to determine top level dev dependencies on linters, and only runs those which are present in the resulting list. This ensures that we don't erroneously run `eslint` when the package is only depending on `standard` (which has a transitive dependency on `eslint`)
- Fixes some style issues on use of variables (mostly adding braces)
- Fixes #47 

🚨  **Note: This should only be merged once `1.10.x` is stable.** 🚨 