### PR TITLE
Use bundled Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 ### Project specific config ###
+language: generic
+
 env:
   global:
     - APM_TEST_PACKAGES=""
-    - ATOM_LINT_WITH_BUNDLED_NODE="false"
+    - ATOM_LINT_WITH_BUNDLED_NODE="true"
 
   matrix:
     - ATOM_CHANNEL=stable
@@ -11,10 +13,6 @@ env:
 os:
   - linux
   - osx
-
-# Installed for linting the project
-language: node_js
-node_js: "6"
 
 ### Generic setup follows ###
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,11 @@
 ### Project specific config ###
 environment:
   APM_TEST_PACKAGES:
-  ATOM_LINT_WITH_BUNDLED_NODE: "false"
+  ATOM_LINT_WITH_BUNDLED_NODE: "true"
 
   matrix:
   - ATOM_CHANNEL: stable
   - ATOM_CHANNEL: beta
-
-install:
-  # Install Node.js to run any configured linters
-  - ps: Install-Product node 6
 
 ### Generic setup follows ###
 build_script:


### PR DESCRIPTION
Change the Travis-CI and AppVeyor scripts to use the bundled Node.js by default. Also removes the steps installing Node.js 6 on the system as it shouldn't be necessary any longer.

Fixes #52.