### PR TITLE
Remove extraneous install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ os:
 ### Generic setup follows ###
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
-# Needed to disable the auto-install step running `npm install`
-install: true
-
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Since the language is now generic in travis.yml, there is no longer any attempt to automaticlaly run `npm install`, so the override can be removed.

Note that CircleCI attempts to be "helpful" and will always attempt to run `npm install` when it sees a `package.json` file, so the equivalent line in `circle.yml` is still necessary.