### PR TITLE
Don't pipe script and misc. CircleCI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ os:
   - osx
 
 ### Generic setup follows ###
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh > build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 # Needed to disable the auto-install step running `npm install`
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ os:
 
 ### Generic setup follows ###
 script:
-  - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh > build-package.sh
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
   - ./build-package.sh
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -48,6 +48,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
   sudo apt-get -f install
   export ATOM_SCRIPT_PATH="atom"
   export APM_SCRIPT_PATH="apm"
+  export NPM_SCRIPT_PATH="/usr/share/atom/resources/app/apm/node_modules/.bin/npm"
 else
   echo "Unknown CI environment, exiting!"
   exit 1

--- a/build-package.sh
+++ b/build-package.sh
@@ -94,7 +94,7 @@ if [ -n "${APM_TEST_PACKAGES}" ]; then
 fi
 
 has_linter() {
-  local result="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
+  result="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
   [ -n "${result}" ]
 }
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -95,8 +95,8 @@ if [ -n "${APM_TEST_PACKAGES}" ]; then
 fi
 
 has_linter() {
-  result="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
-  [ -n "${result}" ]
+  linter_module_path="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
+  [ -n "${linter_module_path}" ]
 }
 
 if has_linter "coffeelint"; then

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 test:
   override:
-    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh > build-package.sh
+    - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
     - chmod u+x build-package.sh
     - ./build-package.sh
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 test:
   override:
-    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
+    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh > build-package.sh
+    - chmod u+x build-package.sh
+    - ./build-package.sh
 
 dependencies:
   override:


### PR DESCRIPTION
* Stop piping the script through to `sh`, if the connection is closed mid-execution the script becomes corrupt. See [here](https://www.seancassidy.me/dont-pipe-to-your-shell.html) for some examples.
* Define `NPM_SCRIPT_PATH` on CircleCI so linting runs on there again.
* Remove `local` from the `has_linter` function, this isn't available in POSIX `sh`.

Fixes #57.