### PR TITLE
Allow linters to be direct dependencies

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -111,7 +111,7 @@ function InstallDependencies() {
 
 
 function HasLinter([String] $LinterName) {
-    $output = &"$script:NPM_SCRIPT_PATH" ls --parseable --dev --depth=0 $LinterName 2>$null
+    $output = &"$script:NPM_SCRIPT_PATH" ls --parseable --depth=0 $LinterName 2>$null
     if ($LastExitCode -eq 0) {
         if ($output.Trim() -ne "") {
             return $true

--- a/build-package.sh
+++ b/build-package.sh
@@ -95,7 +95,7 @@ if [ -n "${APM_TEST_PACKAGES}" ]; then
 fi
 
 has_linter() {
-  linter_module_path="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
+  linter_module_path="$( ${NPM_SCRIPT_PATH} ls --parseable --depth=0 "$1" 2> /dev/null )"
   [ -n "${linter_module_path}" ]
 }
 


### PR DESCRIPTION
If a linter is a direct dependency of a package (eg: `eslint` for `linter-eslint`), then linting was not being ran as it was only searching for `devDependency` packages before. Expand the search to all (top level) dependencies so this will get used.