### PR TITLE
Reorder CircleCI script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,11 @@
-test:
+dependencies:
   override:
     - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
     - chmod u+x build-package.sh
-    - ./build-package.sh
 
-dependencies:
+test:
   override:
-    # If nothing is put here, CircleCI will run `npm install` using the system Node.js
-    - echo "Managed in the script"
+    - ./build-package.sh
 
 machine:
   environment:


### PR DESCRIPTION
Cleanup the CircleCI script after having used this format for a bit:

* Move the dependencies to the top, as they are the most often changed part of the configuration
* Move downloading and setting execute on the script to the dependencies, allowing the removal of the somewhat confusing `echo` statement.