### PR TITLE
Adding ci with atom-beta on CircleCI

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -46,8 +46,15 @@ elif [ "${CIRCLECI}" = "true" ]; then
   sudo dpkg --install atom-amd64.deb || true
   sudo apt-get update
   sudo apt-get -f install
-  export ATOM_SCRIPT_PATH="atom"
-  export APM_SCRIPT_PATH="apm"
+  if [ "${ATOM_CHANNEL}" = "stable" ]; then
+    export ATOM_SCRIPT_NAME="atom"
+    export APM_SCRIPT_NAME="apm"
+  else
+    export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
+    export APM_SCRIPT_NAME="apm-${ATOM_CHANNEL}"
+  fi
+  export ATOM_SCRIPT_PATH="${ATOM_SCRIPT_NAME}"
+  export APM_SCRIPT_PATH="${APM_SCRIPT_NAME}"
   export NPM_SCRIPT_PATH="/usr/share/atom/resources/app/apm/node_modules/.bin/npm"
 else
   echo "Unknown CI environment, exiting!"

--- a/build-package.sh
+++ b/build-package.sh
@@ -47,14 +47,12 @@ elif [ "${CIRCLECI}" = "true" ]; then
   sudo apt-get update
   sudo apt-get -f install
   if [ "${ATOM_CHANNEL}" = "stable" ]; then
-    export ATOM_SCRIPT_NAME="atom"
-    export APM_SCRIPT_NAME="apm"
+    export ATOM_SCRIPT_PATH="atom"
+    export APM_SCRIPT_PATH="apm"
   else
-    export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
-    export APM_SCRIPT_NAME="apm-${ATOM_CHANNEL}"
+    export ATOM_SCRIPT_PATH="atom-${ATOM_CHANNEL}"
+    export APM_SCRIPT_PATH="apm-${ATOM_CHANNEL}"
   fi
-  export ATOM_SCRIPT_PATH="${ATOM_SCRIPT_NAME}"
-  export APM_SCRIPT_PATH="${APM_SCRIPT_NAME}"
   export NPM_SCRIPT_PATH="/usr/share/atom/resources/app/apm/node_modules/.bin/npm"
 else
   echo "Unknown CI environment, exiting!"

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ machine:
   environment:
     ATOM_LINT_WITH_BUNDLED_NODE: "true"
     APM_TEST_PACKAGES: ""
+    ATOM_CHANNEL: "stable"
 
 dependencies:
   override:


### PR DESCRIPTION
This PR adds ci with atom-beta on CircleCI.

Adding environment variable `ATOM_CHANNEL: "beta"` to circle.yml enables ci with atom-beta.

```
dependencies:
  override:
    - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
    - chmod u+x build-package.sh

test:
  override:
    - ./build-package.sh

machine:
  environment:
    ATOM_LINT_WITH_BUNDLED_NODE: "true"
    APM_TEST_PACKAGES: ""
    ATOM_CHANNEL: "beta"
```

- Example circle.yml file
https://github.com/kn1kn1/language-context-free/blob/atom-beta/circle.yml

- Example CircleCI result
https://circleci.com/gh/kn1kn1/language-context-free/277

Please note: this change will not affect current circle.yml for atom stable version.