### PR TITLE
Force enable --assume-yes and --quiet

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -45,7 +45,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
     -o "atom-amd64.deb"
   sudo dpkg --install atom-amd64.deb || true
   sudo apt-get update
-  sudo apt-get -f install
+  sudo apt-get -f --assume-yes --quiet install
   export ATOM_SCRIPT_PATH="atom"
   export APM_SCRIPT_PATH="apm"
   export NPM_SCRIPT_PATH="/usr/share/atom/resources/app/apm/node_modules/.bin/npm"

--- a/build-package.sh
+++ b/build-package.sh
@@ -45,7 +45,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
     -o "atom-amd64.deb"
   sudo dpkg --install atom-amd64.deb || true
   sudo apt-get update
-  sudo apt-get -f --assume-yes --quiet install
+  sudo apt-get --fix-broken --assume-yes --quiet install
   export ATOM_SCRIPT_PATH="atom"
   export APM_SCRIPT_PATH="apm"
   export NPM_SCRIPT_PATH="/usr/share/atom/resources/app/apm/node_modules/.bin/npm"


### PR DESCRIPTION
Although the current CircleCI 1.0 environment has been fixing `apt-get` for us to automatically force enable the `--assume-yes --quiet` options, the new CircleCI 2.0 environment doesn't currently do this on the random Docker images that you can pull in. Explicitly specify these options so the script works in a wider range of environments.