### PR TITLE
Grab the output of atom --version

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -47,10 +47,11 @@ function Unzip
 
 function PrintVersions() {
     Write-Host -NoNewLine "Using Atom version: "
-    & "$script:ATOM_EXE_PATH" --version
+    $atomVer = & "$script:ATOM_EXE_PATH" --version | Out-String
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE
     }
+    Write-Host $atomVer
     Write-Host "Using APM version: "
     & "$script:APM_SCRIPT_PATH" -v
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
When `atom --version` is executed like that in a script it doesn't output in a buffered manner, so no output is being shown. Store the results in a variable and then print the variable to get the output to display properly.

An example build using a script based on this branch can be found [here](https://ci.appveyor.com/project/Arcanemagus/linter-erb/build/145#L24).