### PR TITLE
Properly check bundled Node use

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -16,10 +16,10 @@ $script:APM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\re
 $script:NPM_SCRIPT_PATH = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\node_modules\.bin\npm.cmd"
 
 if ($env:ATOM_LINT_WITH_BUNDLED_NODE -eq "false") {
-  $script:ATOM_LINT_WITH_BUNDLED_NODE = false
+  $script:ATOM_LINT_WITH_BUNDLED_NODE = $FALSE
   $script:NPM_SCRIPT_PATH = "npm"
 } else {
-  $script:ATOM_LINT_WITH_BUNDLED_NODE = true
+  $script:ATOM_LINT_WITH_BUNDLED_NODE = $TRUE
 }
 
 function DownloadAtom() {
@@ -64,7 +64,7 @@ function InstallPackage() {
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE
     }
-    if ($script:ATOM_LINT_WITH_BUNDLED_NODE) {
+    if ($script:ATOM_LINT_WITH_BUNDLED_NODE -eq $TRUE) {
       & "$script:APM_SCRIPT_PATH" install
       # Set the PATH to include the node.exe bundled with APM
       $newPath = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin;$env:PATH"


### PR DESCRIPTION
It turns out the previous method of checking whether or not to use the bundled node on AppVeyor would always return `false` if the setting wasn't specified, contrary to what was assumed.

Example build with the variable unspecified: [146](https://ci.appveyor.com/project/Arcanemagus/linter-erb/build/146)
Example build with the variable defined and set to `true`: [147](https://ci.appveyor.com/project/Arcanemagus/linter-erb/build/147)
Example build with the variable defined and set to `false`: [148](https://ci.appveyor.com/project/Arcanemagus/linter-erb/build/148)