### PR TITLE
add apm to PATH on osx

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -22,6 +22,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
   export ATOM_PATH="./atom"
   export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
   export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
+  export PATH="${PATH}:${TRAVIS_BUILD_DIR}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin"
 elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
   curl -s -L "https://atom.io/download/deb?channel=${ATOM_CHANNEL}" \
     -H 'Accept: application/octet-stream' \


### PR DESCRIPTION
This is causing problems when lazy loading dependencies and calling `apm rebuild` on travis-ci on osx

https://travis-ci.org/UziTech/atom-jasmine2-test-runner/jobs/239372730

here is an issue describing the problem:
https://github.com/UziTech/atom-jasmine2-test-runner/issues/18