### PR TITLE
Fix builds of Atom v1.19.0 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,10 @@ sudo: false
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
-    - libsecret-1-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
Atom v1.19.0 brings with it a native C++ implementation that requires a newer `libstdc++6` version. This comes from the `ubuntu-toolchain-r-test` + `g++-6` requirements.

Also removes the no longer needed `libgnome-keyring-dev` and orders `fakeroot` in the same order that `atom/atom` has it.

Fixes #72.