### PR TITLE
Remove extra steps for newer GLIBCXX on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,8 @@ sudo: false
 
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-6
+    - build-essential
     - fakeroot
     - git
     - libsecret-1-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ os:
   - linux
   - osx
 
-dist: trusty
-
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
@@ -35,6 +33,8 @@ git:
   depth: 10
 
 sudo: false
+
+dist: trusty
 
 addons:
   apt:


### PR DESCRIPTION
Atom v1.19.0-beta2 removed the requirement on the newer `GLIBCXX` version. As this is no longer required the extra steps needed to support it can now be removed from the machine configuration on Travis CI.

Also moves the selection of the Trusty image down into the generic section.

An example build can be found here: https://github.com/AtomLinter/linter-jshint/pull/438