### PR TITLE
Use the MacOS build sequence on Circle

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -2,6 +2,7 @@
 
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 
+echo "Downloading latest Atom release on the ${ATOM_CHANNEL} channel..."
 if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
   curl -s -L "https://atom.io/download/mac?channel=${ATOM_CHANNEL}" \
     -H 'Accept: application/octet-stream' \

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -2,6 +2,7 @@
 
 set -x
 
+echo "*tap tap tap* is this thing on"
 echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -170,9 +170,13 @@ fi
 
 if [ -d ./spec ]; then
   echo "Running specs..."
+
   "${ATOM_SCRIPT_PATH}" --test spec
 elif [ -d ./test ]; then
   echo "Running specs..."
+
+  echo "ATOM_SCRIPT_PATH = ${ATOM_SCRIPT_PATH}"
+  echo "PATH = ${PATH}"
   "${ATOM_SCRIPT_PATH}" --test test
 else
   echo "Missing spec folder! Please consider adding a test suite in './spec' or in './test'"

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-set -x
-
-echo "*tap tap tap* is this thing on"
-echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 
 if [ "${TRAVIS_OS_NAME}" = "osx" ]; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -98,10 +98,12 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   "${APM_SCRIPT_PATH}" install
 
   # Override the PATH to put the Node bundled with APM first
-  if [ "${TRAVIS_OS_NAME}" = "osx" ] || [ "${CIRCLE_BUILD_IMAGE}" = "osx" ]; then
+  if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
-  elif [ "${CIRCLECI}" = "true" ]; then
+  elif [ "${CIRCLECI}" = "true" ] && [ "${CIRCLE_BUILD_IMAGE}" = "osx" ]; then
     # Since CircleCI is a fully installed environment, we use the system path to apm
+    export PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
+  elif [ "${CIRCLECI}" = "true" ]; then
     export PATH="/usr/share/atom/resources/app/apm/bin:${PATH}"
   else
     export PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/bin:${PATH}"

--- a/build-package.sh
+++ b/build-package.sh
@@ -72,6 +72,9 @@ elif [ "${CIRCLECI}" = "true" ]; then
       export APM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
       export NPM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
       export PATH="${PATH}:${TRAVIS_BUILD_DIR}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin"
+
+      # Clear screen saver
+      osascript -e 'tell application "System Events" to keystroke "x"'
       ;;
     *)
       echo "Unsupported CircleCI OS: ${OSTYPE}" >&2

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
@@ -75,7 +75,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
       export PATH="${PATH}:${TRAVIS_BUILD_DIR}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin"
       ;;
     *)
-      echo "Unsupported CircleCI OS" >&2
+      echo "Unsupported CircleCI OS: ${OSTYPE}" >&2
       exit 1
       ;;
     esac

--- a/build-package.sh
+++ b/build-package.sh
@@ -179,8 +179,6 @@ if [ -d ./spec ]; then
 elif [ -d ./test ]; then
   echo "Running specs..."
 
-  echo "ATOM_SCRIPT_PATH = ${ATOM_SCRIPT_PATH}"
-  echo "PATH = ${PATH}"
   "${ATOM_SCRIPT_PATH}" --test test
 else
   echo "Missing spec folder! Please consider adding a test suite in './spec' or in './test'"

--- a/build-package.sh
+++ b/build-package.sh
@@ -60,21 +60,21 @@ elif [ "${CIRCLECI}" = "true" ]; then
       curl -s -L "https://atom.io/download/mac?channel=${ATOM_CHANNEL}" \
         -H 'Accept: application/octet-stream' \
         -o "atom.zip"
-      mkdir atom
-      unzip -q atom.zip -d atom
+      mkdir -p /tmp/atom
+      unzip -q atom.zip -d /tmp/atom
       if [ "${ATOM_CHANNEL}" = "stable" ]; then
         export ATOM_APP_NAME="Atom.app"
         export ATOM_SCRIPT_NAME="atom.sh"
-        export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
+        export ATOM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
       else
         export ATOM_APP_NAME="Atom ${ATOM_CHANNEL}.app"
         export ATOM_SCRIPT_NAME="atom-${ATOM_CHANNEL}"
-        export ATOM_SCRIPT_PATH="./atom-${ATOM_CHANNEL}"
-        ln -s "./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
+        export ATOM_SCRIPT_PATH="/tmp/atom-${ATOM_CHANNEL}"
+        ln -s "/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh" "${ATOM_SCRIPT_PATH}"
       fi
-      export ATOM_PATH="./atom"
-      export APM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
-      export NPM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
+      export ATOM_PATH="/tmp/atom"
+      export APM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/apm"
+      export NPM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin/npm"
       export PATH="${PATH}:${TRAVIS_BUILD_DIR}/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/node_modules/.bin"
       ;;
     *)

--- a/build-package.sh
+++ b/build-package.sh
@@ -101,9 +101,9 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
   elif [ "${CIRCLECI}" = "true" ] && [ "${CIRCLE_BUILD_IMAGE}" = "osx" ]; then
-    # Since CircleCI is a fully installed environment, we use the system path to apm
     export PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
   elif [ "${CIRCLECI}" = "true" ]; then
+    # Since CircleCI/Linux is a fully installed environment, we use the system path to apm
     export PATH="/usr/share/atom/resources/app/apm/bin:${PATH}"
   else
     export PATH="${HOME}/atom/usr/share/${ATOM_SCRIPT_NAME}/resources/app/apm/bin:${PATH}"
@@ -174,11 +174,9 @@ fi
 
 if [ -d ./spec ]; then
   echo "Running specs..."
-
   "${ATOM_SCRIPT_PATH}" --test spec
 elif [ -d ./test ]; then
   echo "Running specs..."
-
   "${ATOM_SCRIPT_PATH}" --test test
 else
   echo "Missing spec folder! Please consider adding a test suite in './spec' or in './test'"

--- a/build-package.sh
+++ b/build-package.sh
@@ -96,7 +96,7 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   "${APM_SCRIPT_PATH}" install
 
   # Override the PATH to put the Node bundled with APM first
-  if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+  if [ "${TRAVIS_OS_NAME}" = "osx" ] || [ "${CIRCLE_BUILD_IMAGE}" = "osx" ]; then
     export PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/apm/bin:${PATH}"
   elif [ "${CIRCLECI}" = "true" ]; then
     # Since CircleCI is a fully installed environment, we use the system path to apm

--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,6 @@ dependencies:
 
 test:
   override:
-    - caffeinate -s build-package.sh
+    - ./build-package.sh
+    # On MacOS:
+    # - caffeinate -s build-package.sh

--- a/circle.yml
+++ b/circle.yml
@@ -10,4 +10,4 @@ dependencies:
 
 test:
   override:
-    - ./build-package.sh
+    - caffeinate -s build-package.sh


### PR DESCRIPTION
Use `${OSTYPE}` to determine which OS we're running on Circle CI. Use the MacOS build sequence.

Before the :shipit: I'd prefer to either (a) customize the CircleCI MacOS to actually work by dogfooding it on atom/github or (b) refactor the copy-pasta to a bash function that gets called by both.