### PR TITLE
Run Standard JS linter on `test` dir

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -129,6 +129,8 @@ function RunLinters() {
     $srcpathexists = Test-Path $srcpath
     $specpath = "$script:PACKAGE_FOLDER\spec"
     $specpathexists = Test-Path $specpath
+    $testpath = "$script:PACKAGE_FOLDER\test"
+    $testpathexists = Test-Path $testpath
     $coffeelintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\coffeelint.cmd"
     $lintwithcoffeelint = HasLinter -LinterName "coffeelint"
     $eslintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\eslint.cmd"
@@ -203,6 +205,30 @@ function RunLinters() {
 
         if ($lintwithstandard) {
             & "$standardpath" spec/**/*.js
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+    }
+
+    if ($testpathexists -and ($lintwithcoffeelint -or $lintwitheslint -or $lintwithstandard)) {
+        Write-Host "Linting package tests..."
+        if ($lintwithcoffeelint) {
+            & "$coffeelintpath" test
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($lintwitheslint) {
+            & "$eslintpath" test
+            if ($LASTEXITCODE -ne 0) {
+                ExitWithCode -exitcode $LASTEXITCODE
+            }
+        }
+
+        if ($lintwithstandard) {
+            & "$standardpath" test/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
             }

--- a/build-package.sh
+++ b/build-package.sh
@@ -176,6 +176,11 @@ if has_linter "standard"; then
     ./node_modules/.bin/standard "spec/**/*.js"
     rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
   fi
+  if [ -d ./test ]; then
+    echo "Linting package tests using standard..."
+    ./node_modules/.bin/standard "test/**/*.js"
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+  fi
 fi
 
 if [ -d ./spec ]; then


### PR DESCRIPTION
When [setting up Standard JS on the teletype package](https://github.com/atom/teletype/pull/252), I noticed that CI isn't linting the JavaScript files in the `test` directory. I see that the `build-package.sh` script [will lint JavaScript files in the `spec` directory](https://github.com/atom/ci/blob/run-standard-js-linter-on-test-dir/build-package.sh#L174-L178), but teletype's tests live in the `test` directory, not the spec directory.

For packages that have A) Standard JS linting enabled and B) have a `test` directory present, this pull request updates `build-package.sh` to lint the JavaScript files in the `test` directory.
