### PR TITLE
Add support for dev channel

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,7 +3,7 @@ $script:PACKAGE_FOLDER = "$env:APPVEYOR_BUILD_FOLDER"
 Set-Location $script:PACKAGE_FOLDER
 $script:ATOM_CHANNEL = "stable"
 $script:ATOM_DIRECTORY_NAME = "Atom"
-if ($env:ATOM_CHANNEL -and (($env:ATOM_CHANNEL.tolower() -ne "stable") -or (($env:ATOM_CHANNEL.tolower() -ne "dev"))) {
+if ($env:ATOM_CHANNEL -and (($env:ATOM_CHANNEL.tolower() -ne "stable") -or (($env:ATOM_CHANNEL.tolower() -ne "dev")))) {
     $script:ATOM_CHANNEL = "$env:ATOM_CHANNEL"
     $script:ATOM_DIRECTORY_NAME = "$script:ATOM_DIRECTORY_NAME "
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(0,1).toupper()

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,7 +3,7 @@ $script:PACKAGE_FOLDER = "$env:APPVEYOR_BUILD_FOLDER"
 Set-Location $script:PACKAGE_FOLDER
 $script:ATOM_CHANNEL = "stable"
 $script:ATOM_DIRECTORY_NAME = "Atom"
-if ($env:ATOM_CHANNEL -and ($env:ATOM_CHANNEL.tolower() -ne "stable")) {
+if ($env:ATOM_CHANNEL -and (($env:ATOM_CHANNEL.tolower() -ne "stable") -or (($env:ATOM_CHANNEL.tolower() -ne "dev"))) {
     $script:ATOM_CHANNEL = "$env:ATOM_CHANNEL"
     $script:ATOM_DIRECTORY_NAME = "$script:ATOM_DIRECTORY_NAME "
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(0,1).toupper()

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,7 +3,7 @@ $script:PACKAGE_FOLDER = "$env:APPVEYOR_BUILD_FOLDER"
 Set-Location $script:PACKAGE_FOLDER
 $script:ATOM_CHANNEL = "stable"
 $script:ATOM_DIRECTORY_NAME = "Atom"
-if ($env:ATOM_CHANNEL -and (($env:ATOM_CHANNEL.tolower() -ne "stable") -or (($env:ATOM_CHANNEL.tolower() -ne "dev")))) {
+if ($env:ATOM_CHANNEL -and (($env:ATOM_CHANNEL.tolower() -ne "stable") -or ($env:ATOM_CHANNEL.tolower() -ne "dev"))) {
     $script:ATOM_CHANNEL = "$env:ATOM_CHANNEL"
     $script:ATOM_DIRECTORY_NAME = "$script:ATOM_DIRECTORY_NAME "
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(0,1).toupper()

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,10 +1,15 @@
 Set-StrictMode -Version Latest
 $script:PACKAGE_FOLDER = "$env:APPVEYOR_BUILD_FOLDER"
 Set-Location $script:PACKAGE_FOLDER
-$script:ATOM_CHANNEL = "stable"
+
+if ($env:ATOM_CHANNEL) {
+  $script:ATOM_CHANNEL = "$env:ATOM_CHANNEL"
+} else {
+  $script:ATOM_CHANNEL = "stable"
+}
+
 $script:ATOM_DIRECTORY_NAME = "Atom"
-if ($env:ATOM_CHANNEL -and (($env:ATOM_CHANNEL.tolower() -ne "stable") -or ($env:ATOM_CHANNEL.tolower() -ne "dev"))) {
-    $script:ATOM_CHANNEL = "$env:ATOM_CHANNEL"
+if (($script:ATOM_CHANNEL.tolower() -ne "stable") -and ($script:ATOM_CHANNEL.tolower() -ne "dev")) {
     $script:ATOM_DIRECTORY_NAME = "$script:ATOM_DIRECTORY_NAME "
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(0,1).toupper()
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(1).tolower()

--- a/build-package.sh
+++ b/build-package.sh
@@ -64,7 +64,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
         -o "atom.zip"
       mkdir -p /tmp/atom
       unzip -q atom.zip -d /tmp/atom
-      if [ "${ATOM_CHANNEL}" = "stable" ]; then
+      if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
         export ATOM_APP_NAME="Atom.app"
         export ATOM_SCRIPT_NAME="atom.sh"
         export ATOM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"

--- a/build-package.sh
+++ b/build-package.sh
@@ -49,7 +49,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
       sudo dpkg --install atom-amd64.deb || true
       sudo apt-get update
       sudo apt-get --fix-broken --assume-yes --quiet install
-      if [ "${ATOM_CHANNEL}" = "stable" ]; then
+      if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
         export ATOM_SCRIPT_PATH="atom"
         export APM_SCRIPT_PATH="apm"
       else

--- a/build-package.sh
+++ b/build-package.sh
@@ -30,7 +30,7 @@ elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
   /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
   export DISPLAY=":99"
   dpkg-deb -x atom-amd64.deb "${HOME}/atom"
-  if [ "${ATOM_CHANNEL}" = "stable" ]; then
+  if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
     export ATOM_SCRIPT_NAME="atom"
     export APM_SCRIPT_NAME="apm"
   else

--- a/build-package.sh
+++ b/build-package.sh
@@ -9,7 +9,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     -o "atom.zip"
   mkdir atom
   unzip -q atom.zip -d atom
-  if [ "${ATOM_CHANNEL}" = "stable" ]; then
+  if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
     export ATOM_APP_NAME="Atom.app"
     export ATOM_SCRIPT_NAME="atom.sh"
     export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"


### PR DESCRIPTION
Add support for running CI against the latest successful build of atom/atom's master branch.

### TODO

- [x] Linux on Travis CI ([example](https://travis-ci.org/atom/teletype/jobs/328153106#L527-L529))
- [x] OS X on Travis CI ([example](https://travis-ci.org/jasonrudolph/significant-other/jobs/328168892#L58-L60))
- [x] Linux on Circle CI ([example](https://circleci.com/gh/jasonrudolph/significant-other/2))
- [x] OS X on Circle CI ([example](https://circleci.com/gh/atom/github/414))
- [x] Windows on AppVeyor ([example](https://ci.appveyor.com/project/Atom/github/build/2126/job/s4cyed1hecdym0ng#L23))

/fyi @smashwilson @damieng @daviwil @nathansobo @as-cii 