### PR TITLE
Update scripts to use consistently-named dev channel builds

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -9,7 +9,7 @@ if ($env:ATOM_CHANNEL) {
 }
 
 $script:ATOM_DIRECTORY_NAME = "Atom"
-if (($script:ATOM_CHANNEL.tolower() -ne "stable") -and ($script:ATOM_CHANNEL.tolower() -ne "dev")) {
+if ($script:ATOM_CHANNEL.tolower() -ne "stable") {
     $script:ATOM_DIRECTORY_NAME = "$script:ATOM_DIRECTORY_NAME "
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(0,1).toupper()
     $script:ATOM_DIRECTORY_NAME += $script:ATOM_CHANNEL.substring(1).tolower()

--- a/build-package.sh
+++ b/build-package.sh
@@ -9,7 +9,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     -o "atom.zip"
   mkdir atom
   unzip -q atom.zip -d atom
-  if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+  if [ "${ATOM_CHANNEL}" = "stable" ]; then
     export ATOM_APP_NAME="Atom.app"
     export ATOM_SCRIPT_NAME="atom.sh"
     export ATOM_SCRIPT_PATH="./atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"
@@ -30,7 +30,7 @@ elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
   /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
   export DISPLAY=":99"
   dpkg-deb -x atom-amd64.deb "${HOME}/atom"
-  if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+  if [ "${ATOM_CHANNEL}" = "stable" ]; then
     export ATOM_SCRIPT_NAME="atom"
     export APM_SCRIPT_NAME="apm"
   else


### PR DESCRIPTION
This PR updates the CI build scripts to use the correct app and path names for the Atom Dev channel.  Essentially, we don't special-case the dev channel anymore and look for its name just like we do for the Beta and Nightly channels.  See PR https://github.com/atom/atom/pull/17680 for more information.