### PR TITLE
Grep for the linter name in npm's output

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -132,7 +132,7 @@ if [ -n "${APM_TEST_PACKAGES}" ]; then
 fi
 
 has_linter() {
-  ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null | grep -q "$1"
+  ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null | grep -q "$1$"
 }
 
 if has_linter "coffeelint"; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -132,8 +132,7 @@ if [ -n "${APM_TEST_PACKAGES}" ]; then
 fi
 
 has_linter() {
-  linter_module_path="$( ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null )"
-  [ -n "${linter_module_path}" ]
+  ${NPM_SCRIPT_PATH} ls --parseable --dev --depth=0 "$1" 2> /dev/null | grep -q "$1"
 }
 
 if has_linter "coffeelint"; then


### PR DESCRIPTION
The format of `npm ls --parseable` changed in the intervening three major versions of npm, which broke our `has_linter` checks. Now when the queried package is missing, npm still outputs the root module path:

```
$ npm ls --parseable --dev --depth=0 coffeelint
/Users/smashwilson/src/atom/teletype
$ npm ls --parseable --dev --depth=0 standard
/Users/smashwilson/src/atom/teletype/node_modules/standard
```

I'm replacing our `-n` check with a pipe to a grep command. grep will still return a nonzero exit code if its input is blank, but will further test that npm's output contains (a line that ends with) the actual package name.

/cc @jasonrudolph 