### PR TITLE
The dev channel now uses a -dev suffix on macOS

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -x
+
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 
 echo "Downloading latest Atom release on the ${ATOM_CHANNEL} channel..."

--- a/build-package.sh
+++ b/build-package.sh
@@ -48,7 +48,7 @@ elif [ "${CIRCLECI}" = "true" ]; then
         -o "atom.zip"
       mkdir -p /tmp/atom
       unzip -q atom.zip -d /tmp/atom
-      if [ "${ATOM_CHANNEL}" = "stable" ] || [ "${ATOM_CHANNEL}" = "dev" ]; then
+      if [ "${ATOM_CHANNEL}" = "stable" ]; then
         export ATOM_APP_NAME="Atom.app"
         export ATOM_SCRIPT_NAME="atom.sh"
         export ATOM_SCRIPT_PATH="/tmp/atom/${ATOM_APP_NAME}/Contents/Resources/app/atom.sh"

--- a/build-package.sh
+++ b/build-package.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -x
-
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 
 echo "Downloading latest Atom release on the ${ATOM_CHANNEL} channel..."


### PR DESCRIPTION
I'm testing this out in atom/github#1663.