### PR TITLE
add ATOM_LINT_WITH env variable

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -130,17 +130,18 @@ function RunLinters() {
     $specpath = "$script:PACKAGE_FOLDER\spec"
     $specpathexists = Test-Path $specpath
     $coffeelintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\coffeelint.cmd"
-    $lintwithcoffeelint = HasLinter -LinterName "coffeelint"
+    $lintwithcoffeelint = (-not (Test-Path env:ATOM_LINT_WITH) -or $env:ATOM_LINT_WITH.tolower() -eq "coffeelint")
+    $lintwithcoffeelint = ($lintwithcoffeelint -and (HasLinter -LinterName "coffeelint"))
     $eslintpath = "$script:PACKAGE_FOLDER\node_modules\.bin\eslint.cmd"
-    $lintwitheslint = HasLinter -LinterName "eslint"
+    $lintwitheslint = (-not (Test-Path env:ATOM_LINT_WITH) -or $env:ATOM_LINT_WITH.tolower() -eq "eslint")
+    $lintwitheslint = ($lintwitheslint -and (HasLinter -LinterName "eslint"))
     $standardpath = "$script:PACKAGE_FOLDER\node_modules\.bin\standard.cmd"
-    $lintwithstandard = HasLinter -LinterName "standard"
-    if (($libpathexists -or $srcpathexists) -and ($lintwithcoffeelint -or $lintwitheslint -or $lintwithstandard)) {
-        Write-Host "Linting package..."
-    }
+    $lintwithstandard = (-not (Test-Path env:ATOM_LINT_WITH) -or $env:ATOM_LINT_WITH.tolower() -eq "standard")
+    $lintwithstandard = ($lintwithstandard -and (HasLinter -LinterName "standard"))
 
     if ($libpathexists) {
         if ($lintwithcoffeelint) {
+            Write-Host "Linting package using coffeescript..."
             & "$coffeelintpath" lib
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -148,6 +149,7 @@ function RunLinters() {
         }
 
         if ($lintwitheslint) {
+            Write-Host "Linting package using eslint..."
             & "$eslintpath" lib
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -155,6 +157,7 @@ function RunLinters() {
         }
 
         if ($lintwithstandard) {
+            Write-Host "Linting package using standard..."
             & "$standardpath" lib/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -164,6 +167,7 @@ function RunLinters() {
 
     if ($srcpathexists) {
         if ($lintwithcoffeelint) {
+            Write-Host "Linting package using coffeelint..."
             & "$coffeelintpath" src
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -171,6 +175,7 @@ function RunLinters() {
         }
 
         if ($lintwitheslint) {
+            Write-Host "Linting package using eslint..."
             & "$eslintpath" src
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -178,6 +183,7 @@ function RunLinters() {
         }
 
         if ($lintwithstandard) {
+            Write-Host "Linting package using standard..."
             & "$standardpath" src/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -185,9 +191,9 @@ function RunLinters() {
         }
     }
 
-    if ($specpathexists -and ($lintwithcoffeelint -or $lintwitheslint -or $lintwithstandard)) {
-        Write-Host "Linting package specs..."
+    if ($specpathexists) {
         if ($lintwithcoffeelint) {
+            Write-Host "Linting package specs using coffeelint..."
             & "$coffeelintpath" spec
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -195,6 +201,7 @@ function RunLinters() {
         }
 
         if ($lintwitheslint) {
+            Write-Host "Linting package specs using eslint..."
             & "$eslintpath" spec
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE
@@ -202,6 +209,7 @@ function RunLinters() {
         }
 
         if ($lintwithstandard) {
+            Write-Host "Linting package specs using standard..."
             & "$standardpath" spec/**/*.js
             if ($LASTEXITCODE -ne 0) {
                 ExitWithCode -exitcode $LASTEXITCODE

--- a/build-package.sh
+++ b/build-package.sh
@@ -99,42 +99,48 @@ has_linter() {
   [ -n "${linter_module_path}" ]
 }
 
-if has_linter "coffeelint"; then
-  if [ -d ./lib ]; then
-    echo "Linting package using coffeelint..."
-    ./node_modules/.bin/coffeelint lib
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
-  fi
-  if [ -d ./spec ]; then
-    echo "Linting package specs using coffeelint..."
-    ./node_modules/.bin/coffeelint spec
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
-  fi
-fi
-
-if has_linter "eslint"; then
-  if [ -d ./lib ]; then
-    echo "Linting package using eslint..."
-    ./node_modules/.bin/eslint lib
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
-  fi
-  if [ -d ./spec ]; then
-    echo "Linting package specs using eslint..."
-    ./node_modules/.bin/eslint spec
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+if [ "${ATOM_LINT_WITH:-coffeelint}" = "coffeelint" ]; then
+  if has_linter "coffeelint"; then
+    if [ -d ./lib ]; then
+      echo "Linting package using coffeelint..."
+      ./node_modules/.bin/coffeelint lib
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
+    if [ -d ./spec ]; then
+      echo "Linting package specs using coffeelint..."
+      ./node_modules/.bin/coffeelint spec
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
   fi
 fi
 
-if has_linter "standard"; then
-  if [ -d ./lib ]; then
-    echo "Linting package using standard..."
-    ./node_modules/.bin/standard "lib/**/*.js"
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+if [ "${ATOM_LINT_WITH:-eslint}" = "eslint" ]; then
+  if has_linter "eslint"; then
+    if [ -d ./lib ]; then
+      echo "Linting package using eslint..."
+      ./node_modules/.bin/eslint lib
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
+    if [ -d ./spec ]; then
+      echo "Linting package specs using eslint..."
+      ./node_modules/.bin/eslint spec
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
   fi
-  if [ -d ./spec ]; then
-    echo "Linting package specs using standard..."
-    ./node_modules/.bin/standard "spec/**/*.js"
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+fi
+
+if [ "${ATOM_LINT_WITH:-standard}" = "standard" ]; then
+  if has_linter "standard"; then
+    if [ -d ./lib ]; then
+      echo "Linting package using standard..."
+      ./node_modules/.bin/standard "lib/**/*.js"
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
+    if [ -d ./spec ]; then
+      echo "Linting package specs using standard..."
+      ./node_modules/.bin/standard "spec/**/*.js"
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
   fi
 fi
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -106,6 +106,11 @@ if [ "${ATOM_LINT_WITH:-coffeelint}" = "coffeelint" ]; then
       ./node_modules/.bin/coffeelint lib
       rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
     fi
+    if [ -d ./src ]; then
+      echo "Linting package using coffeelint..."
+      ./node_modules/.bin/coffeelint src
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
     if [ -d ./spec ]; then
       echo "Linting package specs using coffeelint..."
       ./node_modules/.bin/coffeelint spec
@@ -121,6 +126,11 @@ if [ "${ATOM_LINT_WITH:-eslint}" = "eslint" ]; then
       ./node_modules/.bin/eslint lib
       rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
     fi
+    if [ -d ./src ]; then
+      echo "Linting package using eslint..."
+      ./node_modules/.bin/eslint src
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
     if [ -d ./spec ]; then
       echo "Linting package specs using eslint..."
       ./node_modules/.bin/eslint spec
@@ -134,6 +144,11 @@ if [ "${ATOM_LINT_WITH:-standard}" = "standard" ]; then
     if [ -d ./lib ]; then
       echo "Linting package using standard..."
       ./node_modules/.bin/standard "lib/**/*.js"
+      rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
+    fi
+    if [ -d ./src ]; then
+      echo "Linting package using standard..."
+      ./node_modules/.bin/standard "src/**/*.js"
       rc=$?; if [ $rc -ne 0 ]; then exit $rc; fi
     fi
     if [ -d ./spec ]; then


### PR DESCRIPTION
Check environment variable ATOM_LINT_WITH to allow the option to choose which linter to use (coffelint, eslint, or standard) or to disable linting with ATOM_LINT_WITH=false

The automatic linting can be a problem with packages that use one of the linters (i.e. `linter-coffeelint`) when the linter is supposed to fail in the tests.
https://travis-ci.org/AtomLinter/linter-coffeelint/jobs/434397399#L541

I also added `./src` linting in travis-ci since it is already checked in appveyor