### PR TITLE
updates CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,7 @@ jobs:
         command: sudo apt-get update
     - run:
         name: Install some pre-requisite packages
-        command: sudo apt-get --assume-yes --quiet install curl libxss1 libx11-xcb1 libasound2 xvfb
-        # NOTE: `libxss1 libx11-xcb1 libasound2` should be removed once atom/atom#16812 lands on stable
+        command: sudo apt-get --assume-yes --quiet install curl xvfb
     - run:
         name: Start display server for Atom
         command: /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x16 +extension RANDR


### PR DESCRIPTION
atom/atom#16812 landed on stable, so `libxss1 libx11-xcb1 libasound2` can be removed

[Tested on CircleCI](https://circleci.com/gh/adekbadek/atom-kak-mode/10) and it works fine without `libxss1 libx11-xcb1 libasound2`