### PR TITLE
Use apm ci

### DIFF
--- a/build-package.ps1
+++ b/build-package.ps1
@@ -67,15 +67,44 @@ function PrintVersions() {
 function InstallPackage() {
     Write-Host "Downloading package dependencies..."
     if ($script:ATOM_LINT_WITH_BUNDLED_NODE -eq $TRUE) {
-      & "$script:APM_SCRIPT_PATH" ci
+      if (Test-Path -Path "package-lock.json" -PathType Leaf) {
+        & "$script:APM_SCRIPT_PATH" ci
+        if ($LASTEXITCODE -ne 0) {
+          ExitWithCode -exitcode $LASTEXITCODE
+        }
+      } else {
+        Write-Warning "package-lock.json not found; running apm install instead of apm ci"
+        & "$script:APM_SCRIPT_PATH" install
+        if ($LASTEXITCODE -ne 0) {
+          ExitWithCode -exitcode $LASTEXITCODE
+        }
+
+        & "$script:APM_SCRIPT_PATH" clean
+        if ($LASTEXITCODE -ne 0) {
+          ExitWithCode -exitcode $LASTEXITCODE
+        }
+      }
       # Set the PATH to include the node.exe bundled with APM
       $newPath = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin;$env:PATH"
       $env:PATH = $newPath
       [Environment]::SetEnvironmentVariable("PATH", "$newPath", "User")
     } else {
-      & "$script:APM_SCRIPT_PATH" ci --production
-      if ($LASTEXITCODE -ne 0) {
+      if (Test-Path -Path "package-lock.json" -PathType Leaf) {
+        & "$script:APM_SCRIPT_PATH" ci --production
+        if ($LASTEXITCODE -ne 0) {
+            ExitWithCode -exitcode $LASTEXITCODE
+        }
+      } else {
+        Write-Warning "package-lock.json not found; running apm install instead of apm ci"
+        & "$script:APM_SCRIPT_PATH" install --production
+        if ($LASTEXITCODE -ne 0) {
+            ExitWithCode -exitcode $LASTEXITCODE
+        }
+
+        & "$script:APM_SCRIPT_PATH" clean
+        if ($LASTEXITCODE -ne 0) {
           ExitWithCode -exitcode $LASTEXITCODE
+        }
       }
       # Use the system NPM to install the devDependencies
       Write-Host "Using Node.js version:"

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -89,7 +89,7 @@ function InstallPackage() {
           ExitWithCode -exitcode $LASTEXITCODE
       }
       Write-Host "Installing remaining dependencies..."
-      & npm ci
+      & npm install
     }
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -66,18 +66,14 @@ function PrintVersions() {
 
 function InstallPackage() {
     Write-Host "Downloading package dependencies..."
-    & "$script:APM_SCRIPT_PATH" clean
-    if ($LASTEXITCODE -ne 0) {
-        ExitWithCode -exitcode $LASTEXITCODE
-    }
     if ($script:ATOM_LINT_WITH_BUNDLED_NODE -eq $TRUE) {
-      & "$script:APM_SCRIPT_PATH" install
+      & "$script:APM_SCRIPT_PATH" ci
       # Set the PATH to include the node.exe bundled with APM
       $newPath = "$script:PACKAGE_FOLDER\$script:ATOM_DIRECTORY_NAME\resources\app\apm\bin;$env:PATH"
       $env:PATH = $newPath
       [Environment]::SetEnvironmentVariable("PATH", "$newPath", "User")
     } else {
-      & "$script:APM_SCRIPT_PATH" install --production
+      & "$script:APM_SCRIPT_PATH" ci --production
       if ($LASTEXITCODE -ne 0) {
           ExitWithCode -exitcode $LASTEXITCODE
       }
@@ -93,7 +89,7 @@ function InstallPackage() {
           ExitWithCode -exitcode $LASTEXITCODE
       }
       Write-Host "Installing remaining dependencies..."
-      & npm install
+      & npm ci
     }
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE

--- a/build-package.sh
+++ b/build-package.sh
@@ -95,10 +95,9 @@ echo "Using APM version:"
 "${APM_SCRIPT_PATH}" -v
 
 echo "Downloading package dependencies..."
-"${APM_SCRIPT_PATH}" clean
 
 if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
-  "${APM_SCRIPT_PATH}" install
+  "${APM_SCRIPT_PATH}" ci
 
   # Override the PATH to put the Node bundled with APM first
   if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
@@ -113,7 +112,7 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   fi
 else
   export NPM_SCRIPT_PATH="npm"
-  "${APM_SCRIPT_PATH}" install --production
+  "${APM_SCRIPT_PATH}" ci --production
 
   # Use the system NPM to install the devDependencies
   echo "Using Node version:"

--- a/build-package.sh
+++ b/build-package.sh
@@ -97,7 +97,13 @@ echo "Using APM version:"
 echo "Downloading package dependencies..."
 
 if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
-  "${APM_SCRIPT_PATH}" ci
+  if [ -f "package-lock.json" ]; then
+    "${APM_SCRIPT_PATH}" ci
+  else
+    echo "Warning: package-lock.json not found; running apm install instead of apm ci"
+    "${APM_SCRIPT_PATH}" install
+    "${APM_SCRIPT_PATH}" clean
+  fi
 
   # Override the PATH to put the Node bundled with APM first
   if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
@@ -112,7 +118,13 @@ if [ "${ATOM_LINT_WITH_BUNDLED_NODE:=true}" = "true" ]; then
   fi
 else
   export NPM_SCRIPT_PATH="npm"
-  "${APM_SCRIPT_PATH}" ci --production
+  if [ -f "package-lock.json" ]; then
+    "${APM_SCRIPT_PATH}" ci --production
+  else
+    echo "Warning: package-lock.json not found; running apm install instead of apm ci"
+    "${APM_SCRIPT_PATH}" install --production
+    "${APM_SCRIPT_PATH}" clean
+  fi
 
   # Use the system NPM to install the devDependencies
   echo "Using Node version:"


### PR DESCRIPTION
Benefits:
* Cleans automatically
* Reproducible
* Fast
* Apparently fixes some problems with native modules that `apm install` has when encountering a lockfile

Falls back with a warning to `apm install` if `package-lock.json` does not exist.

Example of a CI run using this branch: https://github.com/atom/bracket-matcher/pull/382
You can see how `apm install` fails, but `apm ci` succeeds.