### PR TITLE
 building on both stable and beta atom channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ jobs:
       # Configurable
       ATOM_LINT_WITH_BUNDLED_NODE: "true"
       APM_TEST_PACKAGES: ""
-      ATOM_CHANNEL: "stable"
     # Machine Setup
     # The following configuration line tells CircleCI to use the specified
     # docker image as the runtime environment for your job.
@@ -37,7 +36,16 @@ jobs:
         name: Make build script executable
         command: chmod u+x build-package.sh
     - run:
-        name: Run package tests
+        name: Run package tests on stable channel
         command: ./build-package.sh
     # On MacOS:
     # - run: caffeinate -s build-package.sh
+        environment:
+          ATOM_CHANNEL: "stable"
+    - run:
+        name: Run package tests on beta channel
+        command: ./build-package.sh
+    # On MacOS:
+    # - run: caffeinate -s build-package.sh
+        environment:
+          ATOM_CHANNEL: "beta"


### PR DESCRIPTION
### Issue or RFC Endorsed by Atom's Maintainers
This change is a proposed improvement. There is no issue open for it.

### Description of the Change
Current configuration allows build only on atom stable channel.  
With this change, Circle-CI script now allows to build on both stable and beta atom channels.

### Alternate Designs
I've tried to use Circle-CI workflows but filtering branches is not supported yet.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
As build job now includes another step to build beta channel, possible side effect could be that process might take more time to build both channels.

### Verification Process
I verified functionality at building [atom-path-intellisense](https://github.com/apercova/atom-path-intellisense) package with proposed [configuration](https://github.com/apercova/atom-path-intellisense/blob/master/.circleci/config.yml)

### Release Notes
The Circle-CI script now allows to build on both stable and beta atom channels.