### PR TITLE
Feat/GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
-    - uses: UziTech/action-setup-atom@v1
+    - uses: UziTech/action-setup-atom@v2
       with:
-        channel: ${{ matrix.channel }}
-    - name: Atom version
-      run: atom -v
-    - name: APM version
-      run: apm -v
+        version: ${{ matrix.channel }}
     - name: Install dependencies
       run: apm install
     - name: Run coffeelint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,85 +2,30 @@ name: CI
 
 on: [push]
 
+env:
+  CI: true
+
 jobs:
-  build-linux-stable:
-    runs-on: ubuntu-latest
-    env:
-      TRAVIS_OS_NAME: linux
-      ATOM_CHANNEL: stable
+  Test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        channel: [stable, beta]
+    runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Get package script
-      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-    - name: Set script permissions
-      run: chmod u+x build-package.sh
-    - name: Build package
-      run: ./build-package.sh
-
-  build-linux-beta:
-    runs-on: ubuntu-latest
-    env:
-      TRAVIS_OS_NAME: linux
-      ATOM_CHANNEL: beta
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Get package script
-      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-    - name: Set script permissions
-      run: chmod u+x build-package.sh
-    - name: Build package
-      run: ./build-package.sh
-
-  build-macos-stable:
-    runs-on: macOS-latest
-    env:
-      TRAVIS_OS_NAME: osx
-      ATOM_CHANNEL: stable
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Get package script
-      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-    - name: Set script permissions
-      run: chmod u+x build-package.sh
-    - name: Build package
-      run: ./build-package.sh
-
-  build-macos-beta:
-    runs-on: macOS-latest
-    env:
-      TRAVIS_OS_NAME: osx
-      ATOM_CHANNEL: beta
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Get package script
-      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-    - name: Set script permissions
-      run: chmod u+x build-package.sh
-    - name: Build package
-      run: ./build-package.sh
-
-  build-windows-stable:
-    runs-on: windows-latest
-    env:
-      ATOM_LINT_WITH_BUNDLED_NODE: true
-      ATOM_CHANNEL: stable
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Run package script
-        run: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
-
-  build-windows-beta:
-    runs-on: windows-latest
-    env:
-      ATOM_LINT_WITH_BUNDLED_NODE: true
-      ATOM_CHANNEL: beta
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Run package script
-        run: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+    - uses: actions/checkout@v1
+    - uses: UziTech/action-setup-atom@v1
+      with:
+        channel: ${{ matrix.channel }}
+    - name: Atom version
+      run: atom -v
+    - name: APM version
+      run: apm -v
+    - name: Install dependencies
+      run: apm install
+    - name: Run coffeelint
+      run: ./node_modules/.bin/coffeelint spec
+    - name: Run standard
+      run: ./node_modules/.bin/standard "spec/**/*.js"
+    - name: Run tests
+      run: atom --test spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,5 @@ jobs:
         version: ${{ matrix.channel }}
     - name: Install dependencies
       run: apm install
-    - name: Run coffeelint
-      run: ./node_modules/.bin/coffeelint spec
-    - name: Run standard
-      run: ./node_modules/.bin/standard "spec/**/*.js"
     - name: Run tests
       run: atom --test spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,17 @@ jobs:
 
     - name: Build package
       run: ./build-package.sh
+
+  build-windows:
+    runs-on:
+      - windows-latest
+
+    env:
+      ATOM_LINT_WITH_BUNDLED_NODE: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Run package script
+        run: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on:
+      - ubuntu-latest
+
+    env:
+      TRAVIS_OS_NAME: linux
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Get package script
+      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+
+    - name: Set script permissions
+      run: chmod u+x build-package.sh
+
+    - name: Build package
+      run: ./build-package.sh
+
+  build-macos:
+    runs-on:
+      - macOS-latest
+
+    env:
+      TRAVIS_OS_NAME: osx
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Get package script
+      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+
+    - name: Set script permissions
+      run: chmod u+x build-package.sh
+
+    - name: Build package
+      run: ./build-package.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,56 +3,84 @@ name: CI
 on: [push]
 
 jobs:
-  build-linux:
-    runs-on:
-      - ubuntu-latest
-
+  build-linux-stable:
+    runs-on: ubuntu-latest
     env:
       TRAVIS_OS_NAME: linux
-
+      ATOM_CHANNEL: stable
     steps:
     - name: Checkout
       uses: actions/checkout@master
-
     - name: Get package script
       run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-
     - name: Set script permissions
       run: chmod u+x build-package.sh
-
     - name: Build package
       run: ./build-package.sh
 
-  build-macos:
-    runs-on:
-      - macOS-latest
+  build-linux-beta:
+    runs-on: ubuntu-latest
+    env:
+      TRAVIS_OS_NAME: linux
+      ATOM_CHANNEL: beta
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Get package script
+      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+    - name: Set script permissions
+      run: chmod u+x build-package.sh
+    - name: Build package
+      run: ./build-package.sh
 
+  build-macos-stable:
+    runs-on: macOS-latest
     env:
       TRAVIS_OS_NAME: osx
-
+      ATOM_CHANNEL: stable
     steps:
     - name: Checkout
       uses: actions/checkout@master
-
     - name: Get package script
       run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-
     - name: Set script permissions
       run: chmod u+x build-package.sh
-
     - name: Build package
       run: ./build-package.sh
 
-  build-windows:
-    runs-on:
-      - windows-latest
+  build-macos-beta:
+    runs-on: macOS-latest
+    env:
+      TRAVIS_OS_NAME: osx
+      ATOM_CHANNEL: beta
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Get package script
+      run: curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+    - name: Set script permissions
+      run: chmod u+x build-package.sh
+    - name: Build package
+      run: ./build-package.sh
 
+  build-windows-stable:
+    runs-on: windows-latest
     env:
       ATOM_LINT_WITH_BUNDLED_NODE: true
-
+      ATOM_CHANNEL: stable
     steps:
       - name: Checkout
         uses: actions/checkout@master
+      - name: Run package script
+        run: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
 
+  build-windows-beta:
+    runs-on: windows-latest
+    env:
+      ATOM_LINT_WITH_BUNDLED_NODE: true
+      ATOM_CHANNEL: beta
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
       - name: Run package script
         run: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))

--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ package's specs.
 
 ### What packages use this?
 
-* [GitHub Actions, Travis CI, CircleCI](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
-* [Appveyor](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)
+* [Linux, macOS](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
+* [Windows](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ package's specs.
 
 ### What does the output look like?
 
--   [macOS @ GitHub Actions](https://github.com/thumperward/auto-create-files/commit/fefbe1e6c9fc15e000eec5904576d55c254e7d76/checks?check_suite_id=293486056)
 -   [macOS @ Travis CI](https://travis-ci.org/atom/wrap-guide/builds/23774579)
 -   [Windows @ Appveyor](https://ci.appveyor.com/project/Atom/wrap-guide/build/12)
 -   [Ubuntu Linux @ CircleCI](https://circleci.com/gh/AtomLinter/linter-stylelint/623)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Templates for building your Atom package and running its specs:
 
-* macOS and Ubuntu Linux: Using [GitHub Actions](https://github.com/features/actions)
+* Windows, macOS and Ubuntu Linux: Using [GitHub Actions](https://github.com/features/actions)
 * macOS and Ubuntu Linux: Using [Travis CI](https://travis-ci.org)
 * Windows: Using [Appveyor](https://appveyor.com)
 * Ubuntu Linux / Docker: Using [CircleCI](https://circleci.com)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 Templates for building your Atom package and running its specs:
 
+* macOS and Ubuntu Linux: Using [GitHub Actions](https://github.com/features/actions)
 * macOS and Ubuntu Linux: Using [Travis CI](https://travis-ci.org)
 * Windows: Using [Appveyor](https://appveyor.com)
 * Ubuntu Linux / Docker: Using [CircleCI](https://circleci.com)
 
 ## Setting up CI for your package
+
+### GitHub Actions
+
+* Copy [.github/workflows/main.yml](https://raw.githubusercontent.com/atom/ci/master/.github/workflows/main.yml)
+  to the same location in your package's repository tree
+* :boom: Your package will now build and run its specs; you can see an example
+  of a configured package [here](https://github.com/thumperward/auto-create-files/actions)
 
 ### Travis CI
 
@@ -42,7 +50,7 @@ Templates for building your Atom package and running its specs:
 
 ### How do I install other Atom packages that my package build depends on?
 
-Set the `APM_TEST_PACKAGES` environment variable in your `.travis.yml` or `.circleci/config.yml` file
+Set the `APM_TEST_PACKAGES` environment variable in your CI configuration file
 to a space-separated list of packages to install before your package's tests
 run.
 
@@ -63,9 +71,9 @@ specs. You can run the specs locally using Atom's spec runner UI from the
 _View > Developer > Run Package Specs_ menu or by pressing `cmd-ctrl-alt-p`. You
 can run `apm help test` to learn more about that command.
 
-#### Travis CI
+#### GitHub Actions, Travis CI, CircleCI
 
-The `.travis.yml` template downloads the [build-package.sh](https://raw.githubusercontent.com/atom/ci/master/build-package.sh)
+The CI template downloads the [build-package.sh](https://raw.githubusercontent.com/atom/ci/master/build-package.sh)
 from this repository. This script then downloads the latest Atom release,
 installs your package's dependencies, and runs the `apm test` command to run
 your package's specs.
@@ -78,18 +86,14 @@ download and install the [latest version of Atom](https://chocolatey.org/package
 are available. Finally, the script runs the `apm test` command to run your
 package's specs.
 
-#### CircleCI
-
-The `.circleci/config.yml` template runs the same script that is used in the Travis-CI builds.
-
-
 ### What does the output look like?
 
+* [macOS @ GitHub Actions](https://github.com/thumperward/auto-create-files/commit/fefbe1e6c9fc15e000eec5904576d55c254e7d76/checks?check_suite_id=293486056)
 * [macOS @ Travis CI](https://travis-ci.org/atom/wrap-guide/builds/23774579)
 * [Windows @ Appveyor](https://ci.appveyor.com/project/Atom/wrap-guide/build/12)
 * [Ubuntu Linux @ CircleCI](https://circleci.com/gh/AtomLinter/linter-stylelint/623)
 
 ### What packages use this?
 
-* [macOS and Ubuntu Linux @ Travis CI and CircleCI](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
-* [Windows @ Appveyor](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)
+* [GitHub Actions, Travis CI, CircleCI](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
+* [Appveyor](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)

--- a/README.md
+++ b/README.md
@@ -2,48 +2,48 @@
 
 Templates for building your Atom package and running its specs:
 
-* Windows, macOS and Ubuntu Linux: Using [GitHub Actions](https://github.com/features/actions)
-* macOS and Ubuntu Linux: Using [Travis CI](https://travis-ci.org)
-* Windows: Using [Appveyor](https://appveyor.com)
-* Ubuntu Linux / Docker: Using [CircleCI](https://circleci.com)
+-   Windows, macOS and Ubuntu Linux: Using [GitHub Actions](https://github.com/features/actions)
+-   macOS and Ubuntu Linux: Using [Travis CI](https://travis-ci.org)
+-   Windows: Using [Appveyor](https://appveyor.com)
+-   Ubuntu Linux / Docker: Using [CircleCI](https://circleci.com)
 
 ## Setting up CI for your package
 
 ### GitHub Actions
 
-* Copy [.github/workflows/main.yml](https://raw.githubusercontent.com/atom/ci/master/.github/workflows/main.yml)
+-   Copy [.github/workflows/main.yml](https://raw.githubusercontent.com/atom/ci/master/.github/workflows/main.yml)
   to the same location in your package's repository tree
-* :boom: Your package will now build and run its specs; you can see an example
+-   :boom: Your package will now build and run its specs; you can see an example
   of a configured package [here](https://github.com/thumperward/auto-create-files/actions)
 
 ### Travis CI
 
-* Sign up for an account on [Travis CI](https://travis-ci.org)
-* Copy [.travis.yml](https://raw.githubusercontent.com/atom/ci/master/.travis.yml)
+-   Sign up for an account on [Travis CI](https://travis-ci.org)
+-   Copy [.travis.yml](https://raw.githubusercontent.com/atom/ci/master/.travis.yml)
   to the root of your package's repository
-* Setup the [Travis CI hook](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A) on your package's repository
-* :boom: Your package will now build and run its specs; you can see an example
+-   Setup the [Travis CI hook](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A) on your package's repository
+-   :boom: Your package will now build and run its specs; you can see an example
   of a configured package [here](https://travis-ci.org/atom/wrap-guide)
 
 ### Appveyor
 
-* Sign up for an account on [Appveyor](https://appveyor.com)
-* Add a new project
-* Ensure the **Ignore appveyor.yml** setting in *Settings > General* is unchecked
-* Copy [appveyor.yml](https://raw.githubusercontent.com/atom/ci/master/appveyor.yml)
+-   Sign up for an account on [Appveyor](https://appveyor.com)
+-   Add a new project
+-   Ensure the `Ignore appveyor.yml` setting in `Settings > General` is unchecked
+-   Copy [appveyor.yml](https://raw.githubusercontent.com/atom/ci/master/appveyor.yml)
   to the root of your package's repository
-* :boom: Your package will now build and run its specs; you can see an example
+-   :boom: Your package will now build and run its specs; you can see an example
   of a configured package [here](https://ci.appveyor.com/project/Atom/wrap-guide)
 
 ### CircleCI
 
-* Sign up for an account on [CircleCI](https://circleci.com)
-* Create a `.circleci` directory at the root of your project
-* Copy [config.yml](https://raw.githubusercontent.com/atom/ci/master/.circleci/config.yml)
+-   Sign up for an account on [CircleCI](https://circleci.com)
+-   Create a `.circleci` directory at the root of your project
+-   Copy [config.yml](https://raw.githubusercontent.com/atom/ci/master/.circleci/config.yml)
   to the new directory
-* Commit the changes and push them up to GitHub
-* [Add a new project](https://circleci.com/docs/2.0/hello-world/) on CircleCI
-* :boom: Your package will now build and run its specs; you can see an example
+-   Commit the changes and push them up to GitHub
+-   [Add a new project](https://circleci.com/docs/2.0/hello-world/) on CircleCI
+-   :boom: Your package will now build and run its specs; you can see an example
   of a configured package [here](https://circleci.com/gh/AtomLinter/linter-stylelint)
 
 ## FAQ
@@ -68,10 +68,16 @@ the latest Atom release [here](https://atom.io/releases).
 
 The `apm test` command assumes your package is using [Jasmine](http://jasmine.github.io)
 specs. You can run the specs locally using Atom's spec runner UI from the
-_View > Developer > Run Package Specs_ menu or by pressing `cmd-ctrl-alt-p`. You
+`View > Developer > Run Package Specs` menu or by pressing `cmd-ctrl-alt-p`. You
 can run `apm help test` to learn more about that command.
 
-#### GitHub Actions, Travis CI, CircleCI
+#### GitHub Actions
+
+The CI template uses the [Atom setup Action](UziTech/action-setup-atom@v1) to
+install and set up Atom on a runner. The script then installs dependencies from
+your package and runs the `apm test` command to run your package's specs.
+
+#### Travis CI, CircleCI
 
 The CI template downloads the [build-package.sh](https://raw.githubusercontent.com/atom/ci/master/build-package.sh)
 from this repository. This script then downloads the latest Atom release,
@@ -88,12 +94,12 @@ package's specs.
 
 ### What does the output look like?
 
-* [macOS @ GitHub Actions](https://github.com/thumperward/auto-create-files/commit/fefbe1e6c9fc15e000eec5904576d55c254e7d76/checks?check_suite_id=293486056)
-* [macOS @ Travis CI](https://travis-ci.org/atom/wrap-guide/builds/23774579)
-* [Windows @ Appveyor](https://ci.appveyor.com/project/Atom/wrap-guide/build/12)
-* [Ubuntu Linux @ CircleCI](https://circleci.com/gh/AtomLinter/linter-stylelint/623)
+-   [macOS @ GitHub Actions](https://github.com/thumperward/auto-create-files/commit/fefbe1e6c9fc15e000eec5904576d55c254e7d76/checks?check_suite_id=293486056)
+-   [macOS @ Travis CI](https://travis-ci.org/atom/wrap-guide/builds/23774579)
+-   [Windows @ Appveyor](https://ci.appveyor.com/project/Atom/wrap-guide/build/12)
+-   [Ubuntu Linux @ CircleCI](https://circleci.com/gh/AtomLinter/linter-stylelint/623)
 
 ### What packages use this?
 
-* [Linux, macOS](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
-* [Windows](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)
+-   [Linux, macOS](https://github.com/search?utf8=%E2%9C%93&q=%22curl+-s+https%3A%2F%2Fraw.githubusercontent.com%2Fatom%2Fci%2Fmaster%2Fbuild-package.sh+|+sh%22+extension%3Ayml&type=Code)
+-   [Windows](https://github.com/search?q="cinst+atom"+extension%3Ayml&type=Code)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ can run `apm help test` to learn more about that command.
 
 #### GitHub Actions
 
-The CI template uses the [Atom setup Action](UziTech/action-setup-atom@v1) to
+The CI template uses the [Atom setup Action](https://github.com/marketplace/actions/setup-atom) to
 install and set up Atom on a runner. The script then installs dependencies from
 your package and runs the `apm test` command to run your package's specs.
 

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -35,7 +35,9 @@ function DownloadAtom() {
     Write-Host "Downloading latest Atom release..."
     $source = "https://atom.io/download/windows_zip?channel=$script:ATOM_CHANNEL"
     $destination = "$script:PACKAGE_FOLDER\atom.zip"
-    appveyor DownloadFile $source -FileName $destination
+
+    Invoke-WebRequest -Uri $source -OutFile $destination
+
     if ($LASTEXITCODE -ne 0) {
         ExitWithCode -exitcode $LASTEXITCODE
     }


### PR DESCRIPTION
### Requirements for Contributing Documentation

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only contribute documentation (for example, markdown files or API docs). To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.

### Description of the Change

This PR adds sample configuration for hooking an Atom package repository up to GitHub Actions. It re-uses the script that handles Travis and CircleCI. As GitHub Actions does not presently expose the OS that a task is running on through a common environment variable, the CI configuration sets `TRAVIS_OS_NAME` appropriately so that the handler script needs no modifications.

### Release Notes

- Added sample configuration file for hooking Atom packages up to GitHub Actions for CI/CD
